### PR TITLE
add annotation to trino service

### DIFF
--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "trino.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
this PR is aim to add annotations to the service.
eg. add annotation to use IAP feature on GKE: 
beta.cloud.google.com/backend-config: '{"default": "backend-config-name"}'