### PR TITLE
add annotations to service

### DIFF
--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "trino.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
this PR aims to add annotations to the service. By adding it, we can add features to the service.
For example, to integrate IAP to the service, we can add this annotations below:
beta.cloud.google.com/backend-config: '{"default": "backend-config-name"}