### PR TITLE
envVars - allow setting Common Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `additionalConfigProperties` |  | `{}` |
 | `additionalLogProperties` |  | `{}` |
 | `additionalCatalogs` |  | `{}` |
+| `envVars` | Common Environment Variables applied to all Coordinator and Worker Pods | `[]` |
 | `securityContext.runAsUser` |  | `1000` |
 | `securityContext.runAsGroup` |  | `1000` |
 | `service.type` |  | `"ClusterIP"` |

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -39,6 +39,8 @@ spec:
         - name: {{ .Chart.Name }}-coordinator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- toYaml .Values.envVars | nindent 12 }}
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -36,6 +36,8 @@ spec:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- toYaml .Values.envVars | nindent 12 }}
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -44,6 +44,8 @@ additionalLogProperties: {}
 
 additionalCatalogs: {}
 
+envVars: []
+
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000


### PR DESCRIPTION
Since TrinoDB allows Environment Variables to be referenced in configuration files and recommends this approach for injecting secrets (https://trino.io/docs/current/security/secrets.html), this PR allows setting common environment variables for the coordinator and worker pods by adding an `envVars` value.

The `envVars` value is an array of objects in the Kubernetes Container Environment Variables format e.g.

```
envVars:
  - name: S3_SECRET_KEY
    valueFrom:
      secretKeyRef:
        name: aws-secret
        key: secret-key
  - name: S3_ENDPOINT
    value: https://s3.site.com
```

The configuration files can then access the secret via the Environment Variable

```
hive.s3.aws-access-key=${ENV:S3_ACCESS_KEY}
```