### PR TITLE
Remove query.max-total-memory-per-node from ConfigMap

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "355"
+appVersion: "370"
 
 icon: https://trino.io/assets/trino.png
 

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -46,7 +46,6 @@ data:
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
-    query.max-total-memory-per-node={{ .Values.server.config.query.maxTotalMemoryPerNode }}
     memory.heap-headroom-per-node={{ .Values.server.config.memory.heapHeadroomPerNode }}
     discovery-server.enabled=true
     discovery.uri=http://localhost:{{ .Values.service.port }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -42,7 +42,6 @@ data:
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
-    query.max-total-memory-per-node={{ .Values.server.config.query.maxTotalMemoryPerNode }}
     memory.heap-headroom-per-node={{ .Values.server.config.memory.heapHeadroomPerNode }}
     discovery.uri=http://{{ template "trino.fullname" . }}:{{ .Values.service.port }}
   {{- range $configValue := .Values.additionalConfigProperties }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -24,7 +24,6 @@ server:
     query:
       maxMemory: "4GB"
       maxMemoryPerNode: "1GB"
-      maxTotalMemoryPerNode: "2GB"
     memory:
       heapHeadroomPerNode: "1GB"
   jvm:


### PR DESCRIPTION
query.max-total-memory-per-node was removed from trino 369. 

This PR updates the chart accordingly.   Since this chart defaults to running the `latest` trino release, its presence prevents trino from booting.