### PR TITLE
Add horizontal pod autoscaler

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -28,6 +28,9 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.jvm.maxHeapSize` |  | `"8G"` |
 | `server.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `server.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
+| `server.autoscaling.enabled` |  | `false` |
+| `server.autoscaling.maxReplicas` |  | `5` |
+| `server.autoscaling.targetCPUUtilizationPercentage` |  | `50` |
 | `additionalNodeProperties` |  | `{}` |
 | `additionalJVMConfig` |  | `{}` |
 | `additionalConfigProperties` |  | `{}` |

--- a/charts/trino/templates/autoscaler.yaml
+++ b/charts/trino/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.server.autoscaling.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "trino.worker" . }}
+spec:
+  maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.server.workers }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "trino.worker" . }}
+  targetCPUUtilizationPercentage: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -32,6 +32,10 @@ server:
       type: "UseG1GC"
       g1:
         heapRegionSize: "32M"
+  autoscaling:
+    enabled: false
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 50
 
 additionalNodeProperties: {}
 


### PR DESCRIPTION
Adds [horizontal pod autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to the helm chart.
A horizontal pod autoscaler simple will simply scale the number of Trino pods based off of CPU usage. 