### PR TITLE
Add Kubernetes service accounts to the chart

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -44,6 +44,9 @@ The following table lists the configurable parameters of the Trino chart and the
 | `nodeSelector` |  | `{}` |
 | `tolerations` |  | `[]` |
 | `affinity` |  | `{}` |
+| `serviceAccount.create` |  | `false` |
+| `serviceAccount.name` |  | `""` |
+| `serviceAccount.annotations` |  | `{}` |
 
 
 

--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -61,3 +61,34 @@ Create chart name and version as used by the chart label.
 {{- define "trino.catalog" -}}
 {{ template "trino.fullname" . }}-catalog
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "trino.labels" -}}
+helm.sh/chart: {{ include "trino.chart" . }}
+{{ include "trino.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "trino.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trino.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "trino.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "trino.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -21,6 +21,7 @@ spec:
         release: {{ .Release.Name }}
         component: coordinator
     spec:
+      serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}
       securityContext:
         runAsUser: {{ .runAsUser }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -23,6 +23,7 @@ spec:
         release: {{ .Release.Name }}
         component: worker
     spec:
+      serviceAccountName: {{ include "trino.serviceAccountName" . }}
       volumes:
         - name: config-volume
           configMap:

--- a/charts/trino/templates/serviceaccount.yaml
+++ b/charts/trino/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "trino.serviceAccountName" . }}
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -75,3 +75,12 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Annotations to add to the service account
+  annotations: {}


### PR DESCRIPTION
This PR will add [Kubernetes service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to the chart, along with defining some common labels in `_helpers.tpl`