### PR TITLE
Provide different JVM configs for co-ordinator and workers

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -31,14 +31,10 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.exchangeManager.baseDir` |  | `"/tmp/trino-local-file-system-exchange-manager"` |
 | `server.workerExtraConfig` |  | `""` |
 | `server.coordinatorExtraConfig` |  | `""` |
-| `server.jvm.maxHeapSize` |  | `"8G"` |
-| `server.jvm.gcMethod.type` |  | `"UseG1GC"` |
-| `server.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
 | `server.autoscaling.enabled` |  | `false` |
 | `server.autoscaling.maxReplicas` |  | `5` |
 | `server.autoscaling.targetCPUUtilizationPercentage` |  | `50` |
 | `additionalNodeProperties` |  | `{}` |
-| `additionalJVMConfig` |  | `{}` |
 | `additionalConfigProperties` |  | `{}` |
 | `additionalLogProperties` |  | `{}` |
 | `additionalExchangeManagerProperties` |  | `{}` |
@@ -49,7 +45,6 @@ The following table lists the configurable parameters of the Trino chart and the
 | `securityContext.runAsGroup` |  | `1000` |
 | `service.type` |  | `"ClusterIP"` |
 | `service.port` |  | `8080` |
-| `resources` |  | `{}` |
 | `nodeSelector` |  | `{}` |
 | `tolerations` |  | `[]` |
 | `affinity` |  | `{}` |

--- a/charts/trino/ci/custom-values.yaml
+++ b/charts/trino/ci/custom-values.yaml
@@ -1,0 +1,19 @@
+# All custom values belong here during testing.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+coordinator:
+  jvm:
+    maxHeapSize: "8G"
+    gcMethod:
+      type: "UseG1GC"
+      g1:
+        heapRegionSize: "32M"
+
+worker:
+  jvm:
+    maxHeapSize: "8G"
+    gcMethod:
+      type: "UseG1GC"
+      g1:
+        heapRegionSize: "32M"

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -19,9 +19,9 @@ data:
 
   jvm.config: |
     -server
-    -Xmx{{ .Values.server.jvm.maxHeapSize }}
-    -XX:+{{ .Values.server.jvm.gcMethod.type }}
-    -XX:G1HeapRegionSize={{ .Values.server.jvm.gcMethod.g1.heapRegionSize }}
+    -Xmx{{ .Values.coordinator.jvm.maxHeapSize }}
+    -XX:+{{ .Values.coordinator.jvm.gcMethod.type }}
+    -XX:G1HeapRegionSize={{ .Values.coordinator.jvm.gcMethod.g1.heapRegionSize }}
     -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
@@ -32,7 +32,7 @@ data:
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.nio.maxCachedBufferSize=2000000
-  {{- range $configValue := .Values.additionalJVMConfig }}
+  {{- range $configValue := .Values.coordinator.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}
 

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -20,9 +20,9 @@ data:
 
   jvm.config: |
     -server
-    -Xmx{{ .Values.server.jvm.maxHeapSize }}
-    -XX:+{{ .Values.server.jvm.gcMethod.type }}
-    -XX:G1HeapRegionSize={{ .Values.server.jvm.gcMethod.g1.heapRegionSize }}
+    -Xmx{{ .Values.worker.jvm.maxHeapSize }}
+    -XX:+{{ .Values.worker.jvm.gcMethod.type }}
+    -XX:G1HeapRegionSize={{ .Values.worker.jvm.gcMethod.g1.heapRegionSize }}
     -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
@@ -33,7 +33,7 @@ data:
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.nio.maxCachedBufferSize=2000000
-  {{- range $configValue := .Values.additionalJVMConfig }}
+  {{- range $configValue := .Values.worker.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}
 

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -73,7 +73,7 @@ spec:
               path: /v1/info
               port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.coordinator.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -61,7 +61,7 @@ spec:
               path: /v1/info
               port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.worker.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/trino/values-coordinator.yaml
+++ b/charts/trino/values-coordinator.yaml
@@ -1,0 +1,25 @@
+# Default values for trino coordinator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+coordinator:
+  jvm:
+    maxHeapSize: "8G"
+    gcMethod:
+      type: "UseG1GC"
+      g1:
+        heapRegionSize: "32M"
+
+  additionalJVMConfig: {}
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi 

--- a/charts/trino/values-worker.yaml
+++ b/charts/trino/values-worker.yaml
@@ -1,0 +1,25 @@
+# Default values for trino worker.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+worker:
+  jvm:
+    maxHeapSize: "8G"
+    gcMethod:
+      type: "UseG1GC"
+      g1:
+        heapRegionSize: "32M"
+
+  additionalJVMConfig: {}
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi 

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -36,20 +36,12 @@ server:
     baseDir: "/tmp/trino-local-file-system-exchange-manager"
   workerExtraConfig: ""
   coordinatorExtraConfig: ""
-  jvm:
-    maxHeapSize: "8G"
-    gcMethod:
-      type: "UseG1GC"
-      g1:
-        heapRegionSize: "32M"
   autoscaling:
     enabled: false
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
 
 additionalNodeProperties: {}
-
-additionalJVMConfig: {}
 
 additionalConfigProperties: {}
 
@@ -80,18 +72,6 @@ securityContext:
 service:
   type: ClusterIP
   port: 8080
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
**[Original PR was here](https://github.com/trinodb/charts/pull/19)**
This PR allows for separating jvm configs for coordinators/workers.