### PR TITLE
Add extraConfig, https, and secretMounts

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -21,6 +21,9 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.log.trino.level` |  | `"INFO"` |
 | `server.config.path` |  | `"/etc/trino"` |
 | `server.config.http.port` |  | `8080` |
+| `server.config.https.enabled` |  | `false` |
+| `server.config.https.port` |  | `8443` |
+| `server.config.https.keystore.path` |  | `""` |
 | `server.config.query.maxMemory` |  | `"4GB"` |
 | `server.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `server.config.memory.heapHeadroomPerNode` |  | `"1GB"` |

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `serviceAccount.create` |  | `false` |
 | `serviceAccount.name` |  | `""` |
 | `serviceAccount.annotations` |  | `{}` |
+| `secretMounts` |  | `[]` |
 
 
 

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -26,6 +26,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
 | `server.exchangeManager.name` |  | `"filesystem"` |
 | `server.exchangeManager.baseDir` |  | `"/tmp/trino-local-file-system-exchange-manager"` |
+| `server.workerExtraConfig` |  | `""` |
+| `server.coordinatorExtraConfig` |  | `""` |
 | `server.jvm.maxHeapSize` |  | `"8G"` |
 | `server.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `server.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -52,6 +52,7 @@ data:
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
   {{- end }}
+  {{ .Values.server.coordinatorExtraConfig | indent 4 }}
 
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -52,6 +52,11 @@ data:
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
   {{- end }}
+  {{- if .Values.server.config.https.enabled }}
+    http-server.https.enabled=true
+    http-server.https.port={{ .Values.server.config.https.port }}
+    http-server.https.keystore.path={{ .Values.server.config.https.keystore.path }}
+  {{- end }}
   {{ .Values.server.coordinatorExtraConfig | indent 4 }}
 
   exchange-manager.properties: |

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -47,6 +47,7 @@ data:
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
   {{- end }}
+  {{ .Values.server.workerExtraConfig | indent 4 }}
 
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -38,6 +38,11 @@ spec:
       initContainers:
       {{-  tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
       {{- end }}
+        {{- range .Values.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}
       imagePullSecrets:
         - name: registry-credentials
       containers:
@@ -51,6 +56,10 @@ spec:
               name: config-volume
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
+            {{- range .Values.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -29,6 +29,8 @@ server:
   exchangeManager:
     name: "filesystem"
     baseDir: "/tmp/trino-local-file-system-exchange-manager"
+  workerExtraConfig: ""
+  coordinatorExtraConfig: ""
   jvm:
     maxHeapSize: "8G"
     gcMethod:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -107,3 +107,5 @@ serviceAccount:
   name: ""
   # Annotations to add to the service account
   annotations: {}
+
+secretMounts: []

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -21,6 +21,11 @@ server:
     path: /etc/trino
     http:
       port: 8080
+    https:
+      enabled: false
+      port: 8443
+      keystore:
+        path: ""
     query:
       maxMemory: "4GB"
       maxMemoryPerNode: "1GB"


### PR DESCRIPTION
This PR will add basic configuration for [HTTPS/TLS](https://trino.io/docs/current/security/tls.html), along with `extraConfig` for additional configuration, and `secretMounts` for the secrets.

I've combined these 3 commits in this PR because they are related to each other.

This will also close #16, and removes a part of #11.