### PR TITLE
Add support for configuring exchange manager properties

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -24,6 +24,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.config.query.maxMemory` |  | `"4GB"` |
 | `server.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `server.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
+| `server.exchangeManager.name` |  | `"filesystem"` |
+| `server.exchangeManager.baseDir` |  | `"/tmp/trino-local-file-system-exchange-manager"` |
 | `server.jvm.maxHeapSize` |  | `"8G"` |
 | `server.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `server.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
@@ -34,6 +36,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `additionalJVMConfig` |  | `{}` |
 | `additionalConfigProperties` |  | `{}` |
 | `additionalLogProperties` |  | `{}` |
+| `additionalExchangeManagerProperties` |  | `{}` |
 | `additionalCatalogs` |  | `{}` |
 | `env` |  | `[]` |
 | `securityContext.runAsUser` |  | `1000` |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -53,6 +53,13 @@ data:
     {{ $configValue }}
   {{- end }}
 
+  exchange-manager.properties: |
+    exchange-manager.name={{ .Values.server.exchangeManager.name }}
+    exchange.base-directory={{ .Values.server.exchangeManager.baseDir }}
+  {{- range $configValue := .Values.additionalExchangeManagerProperties }}
+    {{ $configValue }}
+  {{- end }}
+
   log.properties: |
     io.trino={{ .Values.server.log.trino.level }}
   {{- range $configValue := .Values.additionalLogProperties }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -48,6 +48,13 @@ data:
     {{ $configValue }}
   {{- end }}
 
+  exchange-manager.properties: |
+    exchange-manager.name={{ .Values.server.exchangeManager.name }}
+    exchange.encryption-enabled={{ .Values.server.exchangeManager.encryptionEnabled }}
+  {{- range $configValue := .Values.additionalExchangeManagerProperties }}
+    {{ $configValue }}
+  {{- end }}
+
   log.properties: |
     io.trino={{ .Values.server.log.trino.level }}
   {{- range $configValue := .Values.additionalLogProperties }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -26,6 +26,9 @@ server:
       maxMemoryPerNode: "1GB"
     memory:
       heapHeadroomPerNode: "1GB"
+  exchangeManager:
+    name: "filesystem"
+    baseDir: "/tmp/trino-local-file-system-exchange-manager"
   jvm:
     maxHeapSize: "8G"
     gcMethod:
@@ -44,6 +47,8 @@ additionalJVMConfig: {}
 additionalConfigProperties: {}
 
 additionalLogProperties: {}
+
+additionalExchangeManagerProperties: {}
 
 additionalCatalogs: {}
 


### PR DESCRIPTION
Similar to https://github.com/trinodb/trino/pull/11154, want to exchange-manager.properties as part of the dev setup for Helm charts.

Locally tested and deployed on EKS:
```
helm install --set additionalConfigProperties=\{"retry-policy=TASK","query.initial-hash-partitions=5","fault-tolerant-execution-target-task-input-size=10MB","fault-tolerant-execution-target-task-split-count=4","enable-dynamic-filtering=false","distributed-sort=false"\} \
  --set additionalExchangeManagerProperties=\{"exchange.s3.region=us-east-1","exchange.s3.aws-access-key=accessKey","exchange.s3.aws-secret-key=secretKey"\} \
  --set server.exchangeManager.baseDir="s3n://your-bucket-name"
  demo ./trino-0.4.0.tgz
```

and verified cluster is running in batch mode with S3 used for spooling.