### PR TITLE
Add support for configuring PASSWORD authentication

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -24,6 +24,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.config.https.enabled` |  | `false` |
 | `server.config.https.port` |  | `8443` |
 | `server.config.https.keystore.path` |  | `""` |
+| `server.config.authenticationType` |  | `""` |
 | `server.config.query.maxMemory` |  | `"4GB"` |
 | `server.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `server.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
@@ -53,6 +54,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `nodeSelector` |  | `{}` |
 | `tolerations` |  | `[]` |
 | `affinity` |  | `{}` |
+| `auth` |  | `{}` |
 | `serviceAccount.create` |  | `false` |
 | `serviceAccount.name` |  | `""` |
 | `serviceAccount.annotations` |  | `{}` |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -49,6 +49,9 @@ data:
     memory.heap-headroom-per-node={{ .Values.server.config.memory.heapHeadroomPerNode }}
     discovery-server.enabled=true
     discovery.uri=http://localhost:{{ .Values.service.port }}
+{{- if .Values.server.config.authenticationType }}
+    http-server.authentication.type={{ .Values.server.config.authenticationType }}
+{{- end }}
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
   {{- end }}
@@ -70,6 +73,12 @@ data:
     io.trino={{ .Values.server.log.trino.level }}
   {{- range $configValue := .Values.additionalLogProperties }}
     {{ $configValue }}
+  {{- end }}
+
+  {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+  password-authenticator.properties: |
+    password-authenticator.name=file
+    file.password-file={{ .Values.server.config.path }}/auth/password.db
   {{- end }}
 
 ---

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -34,6 +34,10 @@ spec:
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
+        {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+        - mountPath: {{ .Values.server.config.path }}/auth
+          name: password-volume
+        {{- end }}
       {{- if .Values.initContainers.coordinator }}
       initContainers:
       {{-  tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
@@ -60,6 +64,10 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .path }}
             {{- end }}
+            {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+            - mountPath: {{ .Values.server.config.path }}/auth
+              name: password-volume
+            {{- end }}   
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/trino/templates/secret.yaml
+++ b/charts/trino/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trino-password-authentication
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+data:
+  password.db: {{ .Values.auth.passwordAuth | b64enc }}
+{{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -26,6 +26,9 @@ server:
       port: 8443
       keystore:
         path: ""
+    # Trino supports multiple authentication types: PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS
+    # For more info: https://trino.io/docs/current/security/authentication-types.html
+    authenticationType: ""
     query:
       maxMemory: "4GB"
       maxMemoryPerNode: "1GB"
@@ -98,6 +101,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+auth: {}
+  # Set username and password
+  # https://trino.io/docs/current/security/password-file.html#file-format
+  # passwordAuth: "username:encrypted-password-with-htpasswd"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This PR will add [`authenticationType`](https://trino.io/docs/current/security/authentication-types.html) and configs for `authenticationType = "PASSWORD"`. 

This was cherry picked from [valeriano-manassero/helm-charts](https://github.com/valeriano-manassero/helm-charts/pull/50/files) with some minor changes