### PR TITLE
Use appVersion as default image tag instead of latest

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -20,7 +20,7 @@ version: 0.5.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "372"
+appVersion: "latest"
 
 icon: https://trino.io/assets/trino.png
 

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -13,7 +13,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | ------------------------ | ----------------------- | -------------- |
 | `image.repository` |  | `"trinodb/trino"` |
 | `image.pullPolicy` |  | `"IfNotPresent"` |
-| `image.tag` |  | `"latest"` |
+| `image.tag` |  | `~` |
 | `server.workers` |  | `2` |
 | `server.node.environment` |  | `"production"` |
 | `server.node.dataDir` |  | `"/data/trino"` |

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: trinodb/trino
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
-  tag: latest
+  tag: ~
 
 server:
   workers: 2


### PR DESCRIPTION
This PR changes default image tag to `appVersion` value instead of implicit value of tag `latest`.