### PR TITLE
Add Ingress for web interface

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -50,6 +50,13 @@ The following table lists the configurable parameters of the Trino chart and the
 | `securityContext.runAsGroup` |  | `1000` |
 | `service.type` |  | `"ClusterIP"` |
 | `service.port` |  | `8080` |
+| `ingress.enabled` |  | `false` |
+| `ingress.ingressClassName` |  | `""` |
+| `ingress.labels` |  | `{}` |
+| `ingress.annotations` |  | `{}` |
+| `ingress.tls` |  | `[]` |
+| `ingress.host` |  | `""` |
+| `ingress.path` |  | `/` |
 | `resources` |  | `{}` |
 | `nodeSelector` |  | `{}` |
 | `tolerations` |  | `[]` |

--- a/charts/trino/templates/ingress.yaml
+++ b/charts/trino/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ template "trino.coordinator" . }}
+  labels:
+    app: {{ template "trino.name" . }}
+    chart: {{ template "trino.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ template "trino.fullname" . }}
+                port:
+                  name: http
+            {{- else }}
+            backend:
+              serviceName: {{ template "trino.fullname" . }}
+              servicePort: http
+            {{ end }}
+{{ end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -84,6 +84,15 @@ service:
   type: ClusterIP
   port: 8080
 
+ingress:
+  enabled: false
+  ingressClassName: ""
+  labels: {}
+  annotations: {}
+  tls: []
+  host: ""
+  path: /
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR adds Ingress for Trino web interface and supports `networking.k8s.io/v1`, `networking.k8s.io/v1beta1` and `extensions/v1beta1` versions of Ingress