### PR TITLE
Fix password auth in coordinator deployment

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -35,8 +35,9 @@ spec:
           configMap:
             name: {{ template "trino.catalog" . }}
         {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
-        - mountPath: {{ .Values.server.config.path }}/auth
-          name: password-volume
+        - name: password-volume
+          secret:
+            secretName: trino-password-authentication
         {{- end }}
       {{- if .Values.initContainers.coordinator }}
       initContainers:


### PR DESCRIPTION
In version 0.7.0 of the chart if you try to deploy Trino with file based authentication, you receive this error:

```
$ helm upgrade trino trino/trino --install --version 0.7.0 --values trino.yaml --dry-run --debug
history.go:52: [debug] getting history for release trino
upgrade.go:121: [debug] preparing upgrade for trino
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.volumes[2]): unknown field "mountPath" in io.k8s.api.core.v1.Volume
helm.go:94: [debug] error validating "": error validating data: ValidationError(Deployment.spec.template.spec.volumes[2]): unknown field "mountPath" in io.k8s.api.core.v1.Volume
```

This PR resolves the issue.