### PR TITLE
Add support for managing Kafka table description files

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -71,6 +71,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.resources` |  | `{}` |
 | `worker.livenessProbe` |  | `{}` |
 | `worker.readinessProbe` |  | `{}` |
+| `kafka.mountPath` |  | `"/etc/trino/schemas"` |
+| `kafka.tableDescriptions` |  | `{}` |
 
 
 

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -116,3 +116,17 @@ data:
 {{- end }}{{- end }}
 
 ---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: schemas-volume-coordinator
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+data:
+  {{- range $key, $val := .Values.kafka.tableDescriptions }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+
+---

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -71,4 +71,17 @@ data:
   {{- end }}
 {{ end }}
 
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: schemas-volume-worker
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+data:
+  {{- range $key, $val := .Values.kafka.tableDescriptions }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -34,6 +34,9 @@ spec:
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
+        - name: schemas-volume
+          configMap:
+            name: schemas-volume-coordinator
         {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
         - name: access-control-volume
           configMap:
@@ -66,6 +69,8 @@ spec:
               name: config-volume
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
+            - mountPath: {{ .Values.kafka.mountPath }}
+              name: schemas-volume
             {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
             - mountPath: {{ .Values.server.config.path }}/access-control
               name: access-control-volume

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -31,6 +31,9 @@ spec:
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
+        - name: schemas-volume
+          configMap:
+            name: schemas-volume-worker
       {{- if .Values.initContainers.worker }}
       initContainers:
       {{-  tpl (toYaml .Values.initContainers.worker) . | nindent 6 }}
@@ -48,6 +51,8 @@ spec:
               name: config-volume
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
+            - mountPath: {{ .Values.kafka.mountPath }}
+              name: schemas-volume
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -223,3 +223,40 @@ worker:
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+kafka:
+  mountPath: "/etc/trino/schemas"
+  tableDescriptions: {}
+    # Custom kafka table descriptions that will be mounted in mountPath
+    # testschema.json: |-
+    #   {
+    #     "tableName": "testtable",
+    #     "schemaName": "testschema",
+    #     "topicName": "testtopic",
+    #     "key": {
+    #       "dataFormat": "json",
+    #       "fields": [
+    #         {
+    #           "name": "_key",
+    #           "dataFormat": "VARCHAR",
+    #           "type": "VARCHAR",
+    #           "hidden": "false"
+    #         }
+    #       ]
+    #     },
+    #     "message": {
+    #       "dataFormat": "json",
+    #       "fields": [
+    #         {
+    #           "name": "id",
+    #           "mapping": "id",
+    #           "type": "BIGINT"
+    #         },
+    #         {
+    #           "name": "test_field",
+    #           "mapping": "test_field",
+    #           "type": "VARCHAR"
+    #         }
+    #       ]
+    #     }
+    #   }


### PR DESCRIPTION
This PR will allow adding [custom schemas](https://trino.io/docs/current/connector/kafka.html#table-definition-files) to be mounted in `/etc/trino/schemas`

This was cherry picked from `valeriano-manassero/helm-charts` [`#45`](https://github.com/valeriano-manassero/helm-charts/pull/45) and [`#46`](https://github.com/valeriano-manassero/helm-charts/pull/46)