### PR TITLE
Add secret mounts for both Coordinator and Worker

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -62,12 +62,13 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
 | `coordinator.additionalJVMConfig` |  | `{}` |
 | `coordinator.resources` |  | `{}` |
+| `coordinator.secretMounts` | | `{}` | 
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
 | `worker.additionalJVMConfig` |  | `{}` |
 | `worker.resources` |  | `{}` |
-
+| `worker.secretMounts` | | `{}` |
 
 
 ---

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -44,15 +44,20 @@ spec:
           secret:
             secretName: trino-password-authentication
         {{- end }}
-      {{- if .Values.initContainers.coordinator }}
-      initContainers:
-      {{-  tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
-      {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
         {{- end }}
+        {{- range .Values.coordinator.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}
+      {{- if .Values.initContainers.coordinator }}
+      initContainers:
+      {{-  tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
+      {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       containers:
@@ -71,6 +76,10 @@ spec:
               name: access-control-volume
             {{- end }}{{- end }}
             {{- range .Values.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+            {{- end }}
+            {{- range .Values.coordinator.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
             {{- end }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -31,6 +31,16 @@ spec:
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
+        {{- range .Values.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}            
+        {{- range .Values.worker.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}
       {{- if .Values.initContainers.worker }}
       initContainers:
       {{-  tpl (toYaml .Values.initContainers.worker) . | nindent 6 }}
@@ -48,6 +58,14 @@ spec:
               name: config-volume
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
+            {{- range .Values.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+            {{- end }}
+            {{- range .Values.worker.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -153,6 +153,10 @@ serviceAccount:
   annotations: {}
 
 secretMounts: []
+  # Applies to both the coordinator and worker containers
+  # - name: sample-secret
+  #   secretName: sample-secret
+  #   path: /secrets/sample.json
 
 coordinator:
   jvm:
@@ -175,6 +179,11 @@ coordinator:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  
+  secretMounts: []
+    # - name: sample-secret
+    #   secretName: sample-secret
+    #   path: /secrets/sample.json
 
 worker:
   jvm:
@@ -197,3 +206,8 @@ worker:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  
+  secretMounts: []
+    # - name: sample-secret
+    #   secretName: sample-secret
+    #   path: /secrets/sample.json


### PR DESCRIPTION
This PR turns the original `secretMount` to be added to both the Coordinator and Worker Containers.
It also adds a separate `coordinator.secretMount` and `worker.secretMount` for cases where the mount isn't needed on both.

Not sure if this is the best way, but was trying to solve an issue I was facing while trying to use the hive connector with GCS buckets. Since Google loves using the service_account.json pattern, needed to be able to mount that as a secret to the worker nodes for the Hive Connector to use.