### PR TITLE
Add -XX:+UnlockDiagnosticVMOptions and -XX:+UseAESCTRIntrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can then run `helm search repo trino` to see the charts.
 Then you can install chart using:
 
 ```console
-helm install my-trino trino/trino --version 0.7.0
+helm install my-trino trino/trino --version 0.8.0
 ```
 
 ## Documentation

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -32,6 +32,8 @@ data:
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.nio.maxCachedBufferSize=2000000
+    -XX:+UnlockDiagnosticVMOptions
+    -XX:+UseAESCTRIntrinsics
   {{- range $configValue := .Values.coordinator.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -33,6 +33,8 @@ data:
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.nio.maxCachedBufferSize=2000000
+    -XX:+UnlockDiagnosticVMOptions
+    -XX:+UseAESCTRIntrinsics
   {{- range $configValue := .Values.worker.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}


### PR DESCRIPTION
This PR enables JVM options `-XX:+UnlockDiagnosticVMOptions` and `-XX:+UseAESCTRIntrinsics` to enable intrinsic support for AES CTR/GCM on ARM64. This is motivated by the SSL communication overhead observed with S3.
We observed that it improves performance of network communication with S3 a lot on graviton instances. 

It's enabled in Java 18 by default, which is already released. Therefore risk is minimal.

**Some words of explanation**

In latest Java (OpenJDK) versions the performance of AES CTR/GCM for AARCH64 was significally improved and it was backported to OpenJDK 11 (https://github.com/openjdk/jdk11u-dev/pull/410). The original OpenJDK issue can be found here: https://bugs.openjdk.java.net/browse/JDK-8267993. To use that backport we need to enable it explicitly by
enabling `-XX:+UnlockDiagnosticVMOptions` and `-XX:+UseAESCTRIntrinsics`. It was not enabled by default in the backport to `OpenJDK11` because of conservative approach (as they point in the PR).