### PR TITLE
Add securityContext to worker

### DIFF
--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -31,6 +31,11 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        runAsUser: {{ .runAsUser }}
+        runAsGroup: {{ .runAsGroup }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
- ~~`discovery-server.enabled` has been deprecated and `exchange.base-directory` has been renamed.~~ **EDIT**: Looks like this was merged in by #82 and b6224fb30f33694dd529a30361554e1dd64166af
- `securityContext` block was only applied to the coordinator, not to the worker.