### PR TITLE
Seperate pod assignment config for worker & coordinator

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -49,9 +49,12 @@ The following table lists the configurable parameters of the Trino chart and the
 | `securityContext.runAsGroup` |  | `1000` |
 | `service.type` |  | `"ClusterIP"` |
 | `service.port` |  | `8080` |
-| `nodeSelector` |  | `{}` |
-| `tolerations` |  | `[]` |
-| `affinity` |  | `{}` |
+| `nodeSelector.coordinator` |  | `{}` |
+| `nodeSelector.worker` |  | `{}` |
+| `tolerations.coordinator` |  | `[]` |
+| `tolerations.worker` |  | `[]` |
+| `affinity.coordinator` |  | `{}` |
+| `affinity.worker` |  | `{}` |
 | `auth` |  | `{}` |
 | `serviceAccount.create` |  | `false` |
 | `serviceAccount.name` |  | `""` |

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -107,15 +107,15 @@ spec:
             successThreshold: {{ .Values.coordinator.readinessProbe.successThreshold | default 1 }}
           resources:
             {{- toYaml .Values.coordinator.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.nodeSelector.coordinator }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinity.coordinator }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.tolerations.coordinator }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -77,15 +77,15 @@ spec:
             successThreshold: {{ .Values.worker.readinessProbe.successThreshold | default 1 }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.nodeSelector.worker }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.affinity.worker }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.tolerations.worker }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -132,11 +132,17 @@ service:
   type: ClusterIP
   port: 8080
 
-nodeSelector: {}
+nodeSelector:
+  coordinator: {}
+  worker: {}
 
-tolerations: []
+tolerations:
+  coordinator: []
+  worker: []
 
-affinity: {}
+affinity:
+  coordinator: {}
+  worker: {}
 
 auth: {}
   # Set username and password


### PR DESCRIPTION
This PR updates the `affinity`, `nodeSelector` and `tolerations` values to contain 2 sub-configurations, one for the worker and one for the coordinator. This allows seperate `affinity`, `nodeSelector` and `tolerations` configuration for the workers vs the coordinator pods. This is a common requirement as the resource requirements for a worker pod is usually different compared to a coordinator pod.

This PR enables this change in a non-backward-compatible way. If backward compatibility is required, I can update the PR so that the current format of `affinity`, `nodeSelector` and `tolerations` values are used as a common fallback for worker and coordinator pods.