### PR TITLE
Security contexts for workers

### DIFF
--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -40,6 +40,11 @@ spec:
       {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        runAsUser: {{ .runAsUser }}
+        runAsGroup: {{ .runAsGroup }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
We have a need to provide a security context for workers to allow them to run as specific users. In particular we need them to be able to run as the same user as the coordinator as the shared image used in both needs a level of access to its filesystem. We are trying to run this cluster in an OpenShift environment, and have to deal with its restrictions on available user ids.

This change has been tested within our cluster, but I'm looking for feedback on whether this should be a separate security context for the workers vs coordinator.