### PR TITLE
changing additionalJVMConfig to support [] instead of []

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -34,9 +34,7 @@ data:
     -Djdk.nio.maxCachedBufferSize=2000000
     -XX:+UnlockDiagnosticVMOptions
     -XX:+UseAESCTRIntrinsics
-  {{- range $configValue := .Values.coordinator.additionalJVMConfig }}
-    {{ $configValue }}
-  {{- end }}
+    {{ .Values.coordinator.additionalJVMConfig | nindent 4 }}
 
   config.properties: |
     coordinator=true

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -35,9 +35,7 @@ data:
     -Djdk.nio.maxCachedBufferSize=2000000
     -XX:+UnlockDiagnosticVMOptions
     -XX:+UseAESCTRIntrinsics
-  {{- range $configValue := .Values.worker.additionalJVMConfig }}
-    {{ $configValue }}
-  {{- end }}
+    {{ .Values.worker.additionalJVMConfig | nindent 4 }}
 
   config.properties: |
     coordinator=false

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -162,7 +162,7 @@ coordinator:
       g1:
         heapRegionSize: "32M"
 
-  additionalJVMConfig: []
+  additionalJVMConfig: "" 
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -197,7 +197,7 @@ worker:
       g1:
         heapRegionSize: "32M"
 
-  additionalJVMConfig: []
+  additionalJVMConfig: ""
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -162,7 +162,7 @@ coordinator:
       g1:
         heapRegionSize: "32M"
 
-  additionalJVMConfig: {}
+  additionalJVMConfig: []
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -197,7 +197,7 @@ worker:
       g1:
         heapRegionSize: "32M"
 
-  additionalJVMConfig: {}
+  additionalJVMConfig: []
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
There is a bug in chart while supplying the additionalJVMConfig as the helm chart requires additionalJVMConfig to be an {} but it expects it to be [] in the template. Because of which the values do not update. This merge request should fix it. 

Have tested it for below values
worker:
  additionalJVMConfig:
    - "-Dcom.sun.management.jmxremote=true"
    - "-Dcom.sun.management.jmxremote.authenticate=false"
    - "-Dcom.sun.management.jmxremote.rmi.port=9081"
    - "-Dcom.sun.management.jmxremote.ssl=false"
coordinator:
  additionalJVMConfig:
    - "-Dcom.sun.management.jmxremote=true"
    - "-Dcom.sun.management.jmxremote.authenticate=false"
    - "-Dcom.sun.management.jmxremote.rmi.port=9081"
    - "-Dcom.sun.management.jmxremote.ssl=false"