### PR TITLE
Only create secret if auth.passwordAuth is set

### DIFF
--- a/charts/trino/templates/secret.yaml
+++ b/charts/trino/templates/secret.yaml
@@ -1,4 +1,5 @@
 {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+{{- if .Values.auth.passwordAuth -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +11,5 @@ data:
   {{- if .Values.auth.groups}}
   group.db: {{ .Values.auth.groups | b64enc }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Problem: if users have a solution like [Sealed Secrets](https://sealed-secrets.netlify.app/) which creates Secret objects at runtime from a Kubernetes controller, right now there's no easy way to use this instead of the default provided Secret template.

Solution: if the `auth.passwordAuth` value is not set, do not create a Secret, so that users can create their own secret containing the `passwords.db` file.