### PR TITLE
Expose service port when server.config.https.port set

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -87,6 +87,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.server.config.https.port }}
+            - name: https
+              containerPort: {{ .Values.server.config.https.port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /v1/info

--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -14,6 +14,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.server.config.https.port }}
+    - name: https
+      protocol: TCP
+      port: {{ .Values.server.config.https.port }}
+      targetPort: https
+    {{- end }}
   selector:
     app: {{ template "trino.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Problem: when using password authentication, https is required. However, when a value for `server.config.https.port` is configured, the service cannot be accessed on this port.

Solution: expose https port when `server.config.https.port` value is set.