### PR TITLE
Improve heapHeadroomPerNode configuration

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -28,7 +28,6 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.config.authenticationType` |  | `""` |
 | `server.config.query.maxMemory` |  | `"4GB"` |
 | `server.config.query.maxMemoryPerNode` |  | `"1GB"` |
-| `server.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
 | `server.exchangeManager.name` |  | `"filesystem"` |
 | `server.exchangeManager.baseDir` |  | `"/tmp/trino-local-file-system-exchange-manager"` |
 | `server.workerExtraConfig` |  | `""` |
@@ -60,6 +59,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.jvm.maxHeapSize` |  | `"8G"` |
 | `coordinator.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `coordinator.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
+| `coordinator.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
 | `coordinator.additionalJVMConfig` |  | `{}` |
 | `coordinator.resources` |  | `{}` |
 | `coordinator.livenessProbe` |  | `{}` |
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
+| `worker.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
 | `worker.additionalJVMConfig` |  | `{}` |
 | `worker.resources` |  | `{}` |
 | `worker.livenessProbe` |  | `{}` |

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.jvm.maxHeapSize` |  | `"8G"` |
 | `coordinator.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `coordinator.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
-| `coordinator.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
+| `coordinator.config.memory.heapHeadroomPerNode` |  | `""` |
 | `coordinator.additionalJVMConfig` |  | `{}` |
 | `coordinator.resources` |  | `{}` |
 | `coordinator.livenessProbe` |  | `{}` |
@@ -67,7 +67,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
-| `worker.config.memory.heapHeadroomPerNode` |  | `"1GB"` |
+| `worker.config.memory.heapHeadroomPerNode` |  | `""` |
 | `worker.additionalJVMConfig` |  | `{}` |
 | `worker.resources` |  | `{}` |
 | `worker.livenessProbe` |  | `{}` |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -48,7 +48,9 @@ data:
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
-    memory.heap-headroom-per-node={{ .Values.server.config.memory.heapHeadroomPerNode }}
+{{- if .Values.coordinator.config.memory.heapHeadroomPerNode }}
+    memory.heap-headroom-per-node={{ .Values.coordinator.config.memory.heapHeadroomPerNode }}
+{{- end }}
     discovery-server.enabled=true
     discovery.uri=http://localhost:{{ .Values.service.port }}
 {{- if .Values.server.config.authenticationType }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -44,7 +44,9 @@ data:
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
-    memory.heap-headroom-per-node={{ .Values.server.config.memory.heapHeadroomPerNode }}
+  {{- if .Values.worker.config.memory.heapHeadroomPerNode }}
+    memory.heap-headroom-per-node={{ .Values.worker.config.memory.heapHeadroomPerNode }}
+  {{- end }}
     discovery.uri=http://{{ template "trino.fullname" . }}:{{ .Values.service.port }}
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -162,7 +162,7 @@ coordinator:
 
   config:
     memory:
-      heapHeadroomPerNode: "1GB"
+      heapHeadroomPerNode: ""
 
   additionalJVMConfig: {}
 
@@ -201,7 +201,7 @@ worker:
 
   config:
     memory:
-      heapHeadroomPerNode: "1GB"
+      heapHeadroomPerNode: ""
 
   additionalJVMConfig: {}
 

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -35,8 +35,6 @@ server:
     query:
       maxMemory: "4GB"
       maxMemoryPerNode: "1GB"
-    memory:
-      heapHeadroomPerNode: "1GB"
   exchangeManager:
     name: "filesystem"
     baseDir: "/tmp/trino-local-file-system-exchange-manager"
@@ -162,6 +160,10 @@ coordinator:
       g1:
         heapRegionSize: "32M"
 
+  config:
+    memory:
+      heapHeadroomPerNode: "1GB"
+
   additionalJVMConfig: {}
 
   resources: {}
@@ -196,6 +198,10 @@ worker:
       type: "UseG1GC"
       g1:
         heapRegionSize: "32M"
+
+  config:
+    memory:
+      heapHeadroomPerNode: "1GB"
 
   additionalJVMConfig: {}
 


### PR DESCRIPTION
- Allow configuring different heap headroom for worker and coordinator
- Do not override heapHeadroomPerNode by default