### PR TITLE
Add a parameter to the coordinator and worker deployments to specify pod labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can then run `helm search repo trino` to see the charts.
 Then you can install chart using:
 
 ```console
-helm install my-trino trino/trino --version 0.9.0
+helm install my-trino trino/trino --version 0.9.1
 ```
 
 ## Documentation

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.resources` |  | `{}` |
 | `coordinator.livenessProbe` |  | `{}` |
 | `coordinator.readinessProbe` |  | `{}` |
+| `coordinator.podLabels` |  | `{}` |
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
@@ -72,6 +73,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.resources` |  | `{}` |
 | `worker.livenessProbe` |  | `{}` |
 | `worker.readinessProbe` |  | `{}` |
+| `worker.podLabels` |  | `{}` |
 | `kafka.mountPath` |  | `"/etc/trino/schemas"` |
 | `kafka.tableDescriptions` |  | `{}` |
 

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -20,6 +20,9 @@ spec:
         app: {{ template "trino.name" . }}
         release: {{ .Release.Name }}
         component: coordinator
+        {{- range $key, $val := .Values.coordinator.podLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end}}
     spec:
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -22,6 +22,9 @@ spec:
         app: {{ template "trino.name" . }}
         release: {{ .Release.Name }}
         component: worker
+        {{- range $key, $val := .Values.worker.podLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end}}
     spec:
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       volumes:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -191,6 +191,8 @@ coordinator:
     # failureThreshold: 6
     # successThreshold: 1
 
+  podLabels: {}
+
 worker:
   jvm:
     maxHeapSize: "8G"
@@ -229,6 +231,8 @@ worker:
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+  podLabels: {}
 
 kafka:
   mountPath: "/etc/trino/schemas"


### PR DESCRIPTION
This is useful because in our clusters we use pod labels to manipulate and organize how things are moved/shifter or even how they can access the network on a pod-level so being able to specify pod labels is paramount and this chart didn't support this and we didn't want to "vendorize" it and maintain our own copy of it because of that, hence this contribution 😄 