### PR TITLE
Add envFrom support to the deployment

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `eventListenerProperties` |  | `{}` |
 | `additionalCatalogs` |  | `{}` |
 | `env` |  | `[]` |
+| `envFrom` |  | `[]` |
 | `initContainers` |  | `{}` |
 | `securityContext.runAsUser` |  | `1000` |
 | `securityContext.runAsGroup` |  | `1000` |

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -64,6 +64,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -46,6 +46,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -108,8 +108,11 @@ eventListenerProperties: {}
 
 additionalCatalogs: {}
 
-# Array of EnvVar (https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core)
+# Array of EnvVar (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core)
 env: []
+
+# Array of EnvFromSource (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envfromsource-v1-core)
+envFrom: []
 
 initContainers: {}
   # coordinator:


### PR DESCRIPTION
Allow to inject envFrom values to the deployment. It is a convenient way to automatically inject all entries of a given secret/configMap as environment variables instead of selecting every entries one at a time