### PR TITLE
Split nodeSelectors configs between worker and coordinator.

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -27,7 +27,6 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.config.https.keystore.path` |  | `""` |
 | `server.config.authenticationType` |  | `""` |
 | `server.config.query.maxMemory` |  | `"4GB"` |
-| `server.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `server.exchangeManager.name` |  | `"filesystem"` |
 | `server.exchangeManager.baseDir` |  | `"/tmp/trino-local-file-system-exchange-manager"` |
 | `server.workerExtraConfig` |  | `""` |
@@ -48,9 +47,6 @@ The following table lists the configurable parameters of the Trino chart and the
 | `securityContext.runAsGroup` |  | `1000` |
 | `service.type` |  | `"ClusterIP"` |
 | `service.port` |  | `8080` |
-| `nodeSelector` |  | `{}` |
-| `tolerations` |  | `[]` |
-| `affinity` |  | `{}` |
 | `auth` |  | `{}` |
 | `serviceAccount.create` |  | `false` |
 | `serviceAccount.name` |  | `""` |
@@ -60,18 +56,26 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `coordinator.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
 | `coordinator.config.memory.heapHeadroomPerNode` |  | `""` |
+| `coordinator.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `coordinator.additionalJVMConfig` |  | `{}` |
 | `coordinator.resources` |  | `{}` |
 | `coordinator.livenessProbe` |  | `{}` |
 | `coordinator.readinessProbe` |  | `{}` |
+| `coordinator.nodeSelector` |  | `{}` |
+| `coordinator.tolerations` |  | `[]` |
+| `coordinator.affinity` |  | `{}` |
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
 | `worker.config.memory.heapHeadroomPerNode` |  | `""` |
+| `worker.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `worker.additionalJVMConfig` |  | `{}` |
 | `worker.resources` |  | `{}` |
 | `worker.livenessProbe` |  | `{}` |
 | `worker.readinessProbe` |  | `{}` |
+| `worker.nodeSelector` |  | `{}` |
+| `worker.tolerations` |  | `[]` |
+| `worker.affinity` |  | `{}` |
 | `kafka.mountPath` |  | `"/etc/trino/schemas"` |
 | `kafka.tableDescriptions` |  | `{}` |
 

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -47,7 +47,7 @@ data:
 {{- end }}
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
-    query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
+    query.max-memory-per-node={{ .Values.coordinator.config.query.maxMemoryPerNode }}
 {{- if .Values.coordinator.config.memory.heapHeadroomPerNode }}
     memory.heap-headroom-per-node={{ .Values.coordinator.config.memory.heapHeadroomPerNode }}
 {{- end }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -43,7 +43,7 @@ data:
     coordinator=false
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
-    query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
+    query.max-memory-per-node={{ .Values.worker.config.query.maxMemoryPerNode }}
   {{- if .Values.worker.config.memory.heapHeadroomPerNode }}
     memory.heap-headroom-per-node={{ .Values.worker.config.memory.heapHeadroomPerNode }}
   {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -107,15 +107,15 @@ spec:
             successThreshold: {{ .Values.coordinator.readinessProbe.successThreshold | default 1 }}
           resources:
             {{- toYaml .Values.coordinator.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.coordinator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.coordinator.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.coordinator.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -77,15 +77,15 @@ spec:
             successThreshold: {{ .Values.worker.readinessProbe.successThreshold | default 1 }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -34,7 +34,6 @@ server:
     authenticationType: ""
     query:
       maxMemory: "4GB"
-      maxMemoryPerNode: "1GB"
   exchangeManager:
     name: "filesystem"
     baseDir: "/tmp/trino-local-file-system-exchange-manager"
@@ -130,12 +129,6 @@ service:
   type: ClusterIP
   port: 8080
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 auth: {}
   # Set username and password
   # https://trino.io/docs/current/security/password-file.html#file-format
@@ -163,6 +156,8 @@ coordinator:
   config:
     memory:
       heapHeadroomPerNode: ""
+    query:
+      maxMemoryPerNode: "1GB"
 
   additionalJVMConfig: {}
 
@@ -190,6 +185,12 @@ coordinator:
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
 
 worker:
   jvm:
@@ -202,6 +203,8 @@ worker:
   config:
     memory:
       heapHeadroomPerNode: ""
+    query:
+      maxMemoryPerNode: "1GB"
 
   additionalJVMConfig: {}
 
@@ -229,6 +232,12 @@ worker:
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
 
 kafka:
   mountPath: "/etc/trino/schemas"


### PR DESCRIPTION
This superseeds both existing PRs:
https://github.com/trinodb/charts/pull/67
https://github.com/trinodb/charts/pull/50

As they lack splitting also `maxMemoryPerNode` which is needed to deploy coordinator on different type of node (with different amount of memory) then worker. Without it trying to deploy coordinator on smaller machine will result in error like this:
```Invalid memory configuration. The sum of max query memory per node (161061273600) and heap headroom (34359738368) cannot be larger than the available heap memory (114890375168)```