### PR TITLE
Add missing HTTPS configs

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -22,9 +22,12 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.log.trino.level` |  | `"INFO"` |
 | `server.config.path` |  | `"/etc/trino"` |
 | `server.config.http.port` |  | `8080` |
+| `server.config.http.allowInsecureOverHttp` |  | `false` |
 | `server.config.https.enabled` |  | `false` |
 | `server.config.https.port` |  | `8443` |
 | `server.config.https.keystore.path` |  | `""` |
+| `server.config.https.keystore.keystorePassword` |  | `""` |
+| `server.config.https.keystore.keymanagerPassword` |  | `""` |
 | `server.config.authenticationType` |  | `""` |
 | `server.config.query.maxMemory` |  | `"4GB"` |
 | `server.config.query.maxMemoryPerNode` |  | `"1GB"` |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -63,6 +63,15 @@ data:
     http-server.https.enabled=true
     http-server.https.port={{ .Values.server.config.https.port }}
     http-server.https.keystore.path={{ .Values.server.config.https.keystore.path }}
+    {{- if .Values.server.config.https.keystore.keystorePassword }}
+    http-server.https.keystore.key={{ .Values.server.config.https.keystore.keystorePassword }}
+    {{- end }}
+    {{- if .Values.server.config.https.keystore.keymanagerPassword }}
+    http-server.https.keymanager.password={{ .Values.server.config.https.keystore.keymanagerPassword }}
+    {{- end }}
+    {{- if .Values.server.config.http.allowInsecureOverHttp }}{{- if eq .Values.server.config.http.allowInsecureOverHttp true }}
+    http-server.authentication.allow-insecure-over-http=true
+    {{- end }}
   {{- end }}
   {{ .Values.server.coordinatorExtraConfig | indent 4 }}
 

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -47,15 +47,15 @@ spec:
           secret:
             secretName: trino-password-authentication
         {{- end }}
-      {{- if .Values.initContainers.coordinator }}
-      initContainers:
-      {{-  tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
-      {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
         {{- end }}
+      {{- if .Values.initContainers.coordinator }}
+      initContainers:
+      {{-  tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
+      {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       containers:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -24,11 +24,14 @@ server:
     path: /etc/trino
     http:
       port: 8080
+      allowInsecureOverHttp: false
     https:
       enabled: false
       port: 8443
       keystore:
         path: ""
+        keystorePassword: ""
+        keymanagerPassword: ""
     # Trino supports multiple authentication types: PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS
     # For more info: https://trino.io/docs/current/security/authentication-types.html
     authenticationType: ""
@@ -45,7 +48,8 @@ server:
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
 
-accessControl: {}
+accessControl:
+  {}
   # type: configmap
   # refreshPeriod: 60s
   # # Rules file is mounted to /etc/trino/access-control
@@ -111,7 +115,8 @@ additionalCatalogs: {}
 # Array of EnvVar (https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core)
 env: []
 
-initContainers: {}
+initContainers:
+  {}
   # coordinator:
   #   - name: init-coordinator
   #     image: busybox:1.28
@@ -136,7 +141,8 @@ tolerations: []
 
 affinity: {}
 
-auth: {}
+auth:
+  {}
   # Set username and password
   # https://trino.io/docs/current/security/password-file.html#file-format
   # passwordAuth: "username:encrypted-password-with-htpasswd"
@@ -166,7 +172,8 @@ coordinator:
 
   additionalJVMConfig: {}
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -178,13 +185,15 @@ coordinator:
     #   cpu: 100m
     #   memory: 128Mi
 
-  livenessProbe: {}
+  livenessProbe:
+    {}
     # initialDelaySeconds: 20
     # periodSeconds: 10
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
-  readinessProbe: {}
+  readinessProbe:
+    {}
     # initialDelaySeconds: 20
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -205,7 +214,8 @@ worker:
 
   additionalJVMConfig: {}
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -217,13 +227,15 @@ worker:
     #   cpu: 100m
     #   memory: 128Mi
 
-  livenessProbe: {}
+  livenessProbe:
+    {}
     # initialDelaySeconds: 20
     # periodSeconds: 10
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
-  readinessProbe: {}
+  readinessProbe:
+    {}
     # initialDelaySeconds: 20
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -232,7 +244,8 @@ worker:
 
 kafka:
   mountPath: "/etc/trino/schemas"
-  tableDescriptions: {}
+  tableDescriptions:
+    {}
     # Custom kafka table descriptions that will be mounted in mountPath
     # testschema.json: |-
     #   {


### PR DESCRIPTION
While trying to follow the [official instructions for TLS/HTTPS](https://trino.io/docs/current/security/tls.html#secure-trino-directly), I realised that a lot of the required flags in `config.properties` for the coordinator were not yet implemented.

This PR attempts to implement them to the best of my knowledge. This is my very first open-source contribution, so if I did something wrong I am happy to receive feedback and fix my mistakes / convention breaks accordingly.

The following changes were made:
- `secretMounts` was incorrectly implemented: In `deployment-coordinator.yaml`, the `initContainers` clause was incorrectly in the middle of the `volumes` clause, interrupting the place where the `secretMounts` would be added. I've fixed this to permit correct volume addition for certificates which I assume would be mounted using this mechanism.
- `keystore.keystorePassword` was previously not implemented to support keystores with passwords.
- `keystore.keymanagerPassword` was similarly missing.
- Added support for the `allowInsecureOverHttp` flag.

Edit: Would also like some help on getting around the CLA checks. I've submitted my signed CLA a few days ago, and signed my commits with my email using `git rebase --signoff HEAD~2` after setting my email in my git client, but still getting the error.