### PR TITLE
:sparkles: add extraVolumes and extraVolumeMounts tpl rendering

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -64,6 +64,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.nodeSelector` |  | `{}` |
 | `coordinator.tolerations` |  | `[]` |
 | `coordinator.affinity` |  | `{}` |
+| `coordinator.extraVolumes` |  | `[]` |
+| `coordinator.extraVolumeMounts` |  | `[]` |
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
@@ -76,6 +78,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.nodeSelector` |  | `{}` |
 | `worker.tolerations` |  | `[]` |
 | `worker.affinity` |  | `{}` |
+| `worker.extraVolumes` |  | `[]` |
+| `worker.extraVolumeMounts` |  | `[]` |
 | `kafka.mountPath` |  | `"/etc/trino/schemas"` |
 | `kafka.tableDescriptions` |  | `{}` |
 

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -27,7 +27,6 @@ The following table lists the configurable parameters of the Trino chart and the
 | `server.config.https.keystore.path` |  | `""` |
 | `server.config.authenticationType` |  | `""` |
 | `server.config.query.maxMemory` |  | `"4GB"` |
-| `server.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `server.exchangeManager.name` |  | `"filesystem"` |
 | `server.exchangeManager.baseDir` |  | `"/tmp/trino-local-file-system-exchange-manager"` |
 | `server.workerExtraConfig` |  | `""` |
@@ -48,9 +47,6 @@ The following table lists the configurable parameters of the Trino chart and the
 | `securityContext.runAsGroup` |  | `1000` |
 | `service.type` |  | `"ClusterIP"` |
 | `service.port` |  | `8080` |
-| `nodeSelector` |  | `{}` |
-| `tolerations` |  | `[]` |
-| `affinity` |  | `{}` |
 | `auth` |  | `{}` |
 | `serviceAccount.create` |  | `false` |
 | `serviceAccount.name` |  | `""` |
@@ -60,18 +56,26 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `coordinator.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
 | `coordinator.config.memory.heapHeadroomPerNode` |  | `""` |
+| `coordinator.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `coordinator.additionalJVMConfig` |  | `{}` |
 | `coordinator.resources` |  | `{}` |
 | `coordinator.livenessProbe` |  | `{}` |
 | `coordinator.readinessProbe` |  | `{}` |
+| `coordinator.nodeSelector` |  | `{}` |
+| `coordinator.tolerations` |  | `[]` |
+| `coordinator.affinity` |  | `{}` |
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
 | `worker.config.memory.heapHeadroomPerNode` |  | `""` |
+| `worker.config.query.maxMemoryPerNode` |  | `"1GB"` |
 | `worker.additionalJVMConfig` |  | `{}` |
 | `worker.resources` |  | `{}` |
 | `worker.livenessProbe` |  | `{}` |
 | `worker.readinessProbe` |  | `{}` |
+| `worker.nodeSelector` |  | `{}` |
+| `worker.tolerations` |  | `[]` |
+| `worker.affinity` |  | `{}` |
 | `kafka.mountPath` |  | `"/etc/trino/schemas"` |
 | `kafka.tableDescriptions` |  | `{}` |
 

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -47,7 +47,7 @@ data:
 {{- end }}
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
-    query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
+    query.max-memory-per-node={{ .Values.coordinator.config.query.maxMemoryPerNode }}
 {{- if .Values.coordinator.config.memory.heapHeadroomPerNode }}
     memory.heap-headroom-per-node={{ .Values.coordinator.config.memory.heapHeadroomPerNode }}
 {{- end }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -43,7 +43,7 @@ data:
     coordinator=false
     http-server.http.port={{ .Values.service.port }}
     query.max-memory={{ .Values.server.config.query.maxMemory }}
-    query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
+    query.max-memory-per-node={{ .Values.worker.config.query.maxMemoryPerNode }}
   {{- if .Values.worker.config.memory.heapHeadroomPerNode }}
     memory.heap-headroom-per-node={{ .Values.worker.config.memory.heapHeadroomPerNode }}
   {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -107,15 +107,15 @@ spec:
             successThreshold: {{ .Values.coordinator.readinessProbe.successThreshold | default 1 }}
           resources:
             {{- toYaml .Values.coordinator.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.coordinator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.coordinator.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.coordinator.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -47,6 +47,9 @@ spec:
           secret:
             secretName: trino-password-authentication
         {{- end }}
+        {{- if .Values.coordinator.extraVolumes }}
+        {{- tpl (toYaml .Values.coordinator.extraVolumes) . | nindent 8 }}
+        {{- end }}
       {{- if .Values.initContainers.coordinator }}
       initContainers:
       {{-  tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
@@ -82,6 +85,9 @@ spec:
             {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
             - mountPath: {{ .Values.server.config.path }}/auth
               name: password-volume
+            {{- end }}
+            {{- if .Values.coordinator.extraVolumeMounts }}
+            {{- tpl (toYaml .Values.coordinator.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -77,15 +77,15 @@ spec:
             successThreshold: {{ .Values.worker.readinessProbe.successThreshold | default 1 }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -34,6 +34,9 @@ spec:
         - name: schemas-volume
           configMap:
             name: schemas-volume-worker
+        {{- if .Values.worker.extraVolumes }}
+        {{- tpl (toYaml .Values.worker.extraVolumes) . | nindent 8 }}
+        {{- end }}
       {{- if .Values.initContainers.worker }}
       initContainers:
       {{-  tpl (toYaml .Values.initContainers.worker) . | nindent 6 }}
@@ -53,6 +56,9 @@ spec:
               name: catalog-volume
             - mountPath: {{ .Values.kafka.mountPath }}
               name: schemas-volume
+            {{- if .Values.worker.extraVolumeMounts }}
+            {{- tpl (toYaml .Values.worker.extraVolumeMounts) . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -192,6 +192,10 @@ coordinator:
 
   affinity: {}
 
+  extraVolumeMounts: []
+
+  extraVolumes: []
+
 worker:
   jvm:
     maxHeapSize: "8G"
@@ -238,6 +242,10 @@ worker:
   tolerations: []
 
   affinity: {}
+
+  extraVolumeMounts: []
+
+  extraVolumes: []
 
 kafka:
   mountPath: "/etc/trino/schemas"

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -34,7 +34,6 @@ server:
     authenticationType: ""
     query:
       maxMemory: "4GB"
-      maxMemoryPerNode: "1GB"
   exchangeManager:
     name: "filesystem"
     baseDir: "/tmp/trino-local-file-system-exchange-manager"
@@ -130,12 +129,6 @@ service:
   type: ClusterIP
   port: 8080
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 auth: {}
   # Set username and password
   # https://trino.io/docs/current/security/password-file.html#file-format
@@ -163,6 +156,8 @@ coordinator:
   config:
     memory:
       heapHeadroomPerNode: ""
+    query:
+      maxMemoryPerNode: "1GB"
 
   additionalJVMConfig: {}
 
@@ -190,6 +185,12 @@ coordinator:
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
 
 worker:
   jvm:
@@ -202,6 +203,8 @@ worker:
   config:
     memory:
       heapHeadroomPerNode: ""
+    query:
+      maxMemoryPerNode: "1GB"
 
   additionalJVMConfig: {}
 
@@ -229,6 +232,12 @@ worker:
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
 
 kafka:
   mountPath: "/etc/trino/schemas"


### PR DESCRIPTION
Give the ability to add extraVolumes and extraVolumeMounts.
Typically, on a cluster with nonRoot pods strategy (OpenShift), we have to change the dataDir, because it's owned by root (the random uid can't write inside).
It would be great to give the possibility to add an emptyDir or pvc.