### PR TITLE
Allow annotations and labels for the worker and coordinator pods

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -66,6 +66,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.tolerations` |  | `[]` |
 | `coordinator.affinity` |  | `{}` |
 | `coordinator.additionalConfigFiles` |  | `{}` |
+| `coordinator.annotations` |  | `{}` |
+| `coordinator.labels` |  | `{}` |
 | `worker.jvm.maxHeapSize` |  | `"8G"` |
 | `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
@@ -80,6 +82,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.tolerations` |  | `[]` |
 | `worker.affinity` |  | `{}` |
 | `worker.additionalConfigFiles` |  | `{}` |
+| `worker.annotations` |  | `{}` |
+| `worker.labels` |  | `{}` |
 | `kafka.mountPath` |  | `"/etc/trino/schemas"` |
 | `kafka.tableDescriptions` |  | `{}` |
 

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -16,10 +16,17 @@ spec:
       component: coordinator
   template:
     metadata:
+      {{- if .Values.coordinator.annotations }}
+      annotations:
+      {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "trino.name" . }}
         release: {{ .Release.Name }}
         component: coordinator
+        {{- if .Values.coordinator.labels }}
+        {{- tpl (toYaml .Values.coordinator.labels) . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -18,10 +18,17 @@ spec:
       component: worker
   template:
     metadata:
+      {{- if .Values.worker.annotations }}
+      annotations:
+      {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "trino.name" . }}
         release: {{ .Release.Name }}
         component: worker
+        {{- if .Values.worker.labels }}
+        {{- tpl (toYaml .Values.worker.labels) . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       volumes:
@@ -36,7 +43,7 @@ spec:
             name: schemas-volume-worker
       {{- if .Values.initContainers.worker }}
       initContainers:
-      {{-  tpl (toYaml .Values.initContainers.worker) . | nindent 6 }}
+      {{- tpl (toYaml .Values.initContainers.worker) . | nindent 6 }}
       {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -196,6 +196,10 @@ coordinator:
 
   additionalConfigFiles: {}
 
+  annotations: {}
+
+  labels: {}
+
 worker:
   jvm:
     maxHeapSize: "8G"
@@ -246,6 +250,10 @@ worker:
   affinity: {}
 
   additionalConfigFiles: {}
+
+  annotations: {}
+
+  labels: {}
 
 kafka:
   mountPath: "/etc/trino/schemas"


### PR DESCRIPTION
Annotations are useful for integrating with a service mesh and/or cloud providers.

Also see https://github.com/trinodb/charts/pull/54.  I noticed the CLA wasn't signed yet for that PR.  I can port those changes here if needed. 

