### PR TITLE
Added auth.passwordAuthSecret value for custom passworddb secret name

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -61,7 +61,11 @@ spec:
         {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
         - name: password-volume
           secret:
+            {{- if and .Values.auth .Values.auth.passwordAuthSecret }}
+            secretName: {{ .Values.auth.passwordAuthSecret }}
+            {{- else }}
             secretName: trino-password-authentication
+            {{- end }}
             items:
               - key: password.db
                 path: password.db

--- a/charts/trino/templates/secret.yaml
+++ b/charts/trino/templates/secret.yaml
@@ -2,7 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if and .Values.auth .Values.auth.passwordAuthSecret }}
+  name: {{ .Values.auth.passwordAuthSecret }}
+  {{- else }}
   name: trino-password-authentication
+  {{- end }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}
 data:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -153,6 +153,8 @@ auth: {}
   # Set username and password
   # https://trino.io/docs/current/security/password-file.html#file-format
   # passwordAuth: "username:encrypted-password-with-htpasswd"
+  # or set the name of a secret containing this file in the password.db key
+  # passwordAuthSecret: "trino-password-authentication"
   # Set users' groups
   # https://trino.io/docs/current/security/group-file.html#file-format
   # refreshPeriod: 5s


### PR DESCRIPTION
This allows users to change the name of the secret used for storing the password auth DB.

See also: #59 - which means you can BYO secret. When combined with this PR, you can BYO secret with any name.