### PR TITLE
Remove obsolete parameter discovery-server.enabled

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -51,7 +51,6 @@ data:
 {{- if .Values.coordinator.config.memory.heapHeadroomPerNode }}
     memory.heap-headroom-per-node={{ .Values.coordinator.config.memory.heapHeadroomPerNode }}
 {{- end }}
-    discovery-server.enabled=true
     discovery.uri=http://localhost:{{ .Values.service.port }}
 {{- if .Values.server.config.authenticationType }}
     http-server.authentication.type={{ .Values.server.config.authenticationType }}


### PR DESCRIPTION
It seems discovery-server.enabled is obsolete. This commit will stop warnings about this.