### PR TITLE
Enable password authentication if other authentication methods are also set

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -89,7 +89,7 @@ data:
     {{ $configValue }}
   {{- end }}
 
-  {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+  {{- if contains "PASSWORD" .Values.server.config.authenticationType }}
   password-authenticator.properties: |
     password-authenticator.name=file
     file.password-file={{ .Values.server.config.path }}/auth/password.db

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -32,7 +32,7 @@ spec:
       {{- with .Values.securityContext }}
       securityContext:
         runAsUser: {{ .runAsUser }}
-        runAsGroup: {{ .runAsGroup }}
+        runAsGroup: {{ .runAsGroup }}   
       {{- end }}
       volumes:
         - name: config-volume
@@ -49,7 +49,7 @@ spec:
           configMap:
             name: trino-access-control-volume-coordinator
         {{- end }}{{- end }}
-        {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+        {{- if contains "PASSWORD" .Values.server.config.authenticationType }}
         - name: password-volume
           secret:
             secretName: trino-password-authentication
@@ -88,7 +88,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .path }}
             {{- end }}
-            {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+            {{- if contains "PASSWORD" .Values.server.config.authenticationType }}
             - mountPath: {{ .Values.server.config.path }}/auth
               name: password-volume
             {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -69,6 +69,10 @@ spec:
         - name: {{ .Chart.Name }}-coordinator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.securityContext.containers }}
+          securityContext:
+             {{ toYaml .Values.securityContext.containers | nindent 12 }}
+          {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
           envFrom:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -56,6 +56,10 @@ spec:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.securityContext.containers }}
+          securityContext:
+             {{ toYaml .Values.securityContext.containers | nindent 12 }}
+          {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
           envFrom:

--- a/charts/trino/templates/secret.yaml
+++ b/charts/trino/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.server.config.authenticationType "PASSWORD" }}
+{{- if and (eq .Values.server.config.authenticationType "PASSWORD") (.Values.auth.passwordAuth) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -136,6 +136,7 @@ auth: {}
   # Set username and password
   # https://trino.io/docs/current/security/password-file.html#file-format
   # passwordAuth: "username:encrypted-password-with-htpasswd"
+  # To use an externally created secret simply leave blank
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -127,6 +127,7 @@ initContainers: {}
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
+  containers: {}
 
 service:
   type: ClusterIP


### PR DESCRIPTION
The issue with password authentication working only when it is set as the only authentication type has been fixed. Since now in the templates it checks for a substring instead of equality.

Furthermore, it is now possible to use an externally created secret for the password file.