### PR TITLE
Update configmap-coordinator.yaml remove indentation

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -63,7 +63,7 @@ data:
     http-server.https.port={{ .Values.server.config.https.port }}
     http-server.https.keystore.path={{ .Values.server.config.https.keystore.path }}
   {{- end }}
-  {{ .Values.server.coordinatorExtraConfig }}
+{{ .Values.server.coordinatorExtraConfig | indent 4 }}
 
 {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
   access-control.properties: |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -63,7 +63,7 @@ data:
     http-server.https.port={{ .Values.server.config.https.port }}
     http-server.https.keystore.path={{ .Values.server.config.https.keystore.path }}
   {{- end }}
-  {{ .Values.server.coordinatorExtraConfig | indent 4 }}
+  {{ .Values.server.coordinatorExtraConfig }}
 
 {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
   access-control.properties: |

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -51,7 +51,7 @@ data:
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
   {{- end }}
-  {{ .Values.server.workerExtraConfig | indent 4 }}
+{{ .Values.server.workerExtraConfig | indent 4 }}
 
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}


### PR DESCRIPTION
With current chart, if we add 
```
server:
    coordinatorExtraConfig: "query.client.timeout=5m"
```
then
`config.properties` in coordinator configMap turns out with config extra indented:

```
coordinator=true
node-scheduler.include-coordinator=false
http-server.http.port=8080
query.max-memory=2GB
query.max-memory-per-node=1GB
memory.heap-headroom-per-node=1GB
discovery-server.enabled=true
discovery.uri=http://localhost:8080
  query.client.timeout=5m
```