### PR TITLE
Add common labels

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -87,6 +87,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.labels` |  | `{}` |
 | `kafka.mountPath` |  | `"/etc/trino/schemas"` |
 | `kafka.tableDescriptions` |  | `{}` |
+| `commonLabels` | Labels that get applied to every resource's metadata | `{}` |
 
 
 

--- a/charts/trino/templates/autoscaler.yaml
+++ b/charts/trino/templates/autoscaler.yaml
@@ -3,6 +3,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "trino.worker" . }}
+  {{- if .Values.commonLabels }}
+  labels:
+    {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
+  {{- end }}
 spec:
   maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.server.workers }}

--- a/charts/trino/templates/configmap-catalog.yaml
+++ b/charts/trino/templates/configmap-catalog.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: catalogs
+    {{- if .Values.commonLabels }}
+    {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
+    {{- end }}
 data:
   tpch.properties: |
     connector.name=tpch

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: coordinator
+    {{- if .Values.commonLabels }}
+    {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
+    {{- end }}
 data:
   node.properties: |
     node.environment={{ .Values.server.node.environment }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: worker
+    {{- if .Values.commonLabels }}
+    {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
+    {{- end }}
 data:
   node.properties: |
     node.environment={{ .Values.server.node.environment }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: coordinator
+    {{- if .Values.commonLabels }}
+    {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: worker
+    {{- if .Values.commonLabels }}
+    {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.server.workers }}
   selector:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -294,3 +294,5 @@ kafka:
     #       ]
     #     }
     #   }
+
+commonLabels: {}  # Labels that get applied to every resource's metadata


### PR DESCRIPTION
Some organisations (like mine) require certain labels to be present on every Kubernetes resource, for example, a resource ownership label (which team owns a resource).

This PR adds `commonLabels` option that adds labels to every resource to make this use case possible.