### PR TITLE
Add coordinatorExtraNodeConfig and workerExtraNodeConfig

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -16,6 +16,7 @@ data:
   {{- range $configValue := .Values.additionalNodeProperties }}
     {{ $configValue }}
   {{- end }}
+  {{ .Values.server.coordinatorExtraNodeConfig | indent 4 }}
 
   jvm.config: |
     -server

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -17,6 +17,7 @@ data:
   {{- range $configValue := .Values.additionalNodeProperties }}
     {{ $configValue }}
   {{- end }}
+  {{ .Values.server.workerExtraNodeConfig | indent 4 }}
 
   jvm.config: |
     -server

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -38,7 +38,9 @@ server:
     name: "filesystem"
     baseDir: "/tmp/trino-local-file-system-exchange-manager"
   workerExtraConfig: ""
+  workerExtraNodeConfig: ""
   coordinatorExtraConfig: ""
+  coordinatorExtraNodeConfig: ""
   autoscaling:
     enabled: false
     maxReplicas: 5


### PR DESCRIPTION
This will be useful when we want to add different line in node.properties for coordinator and workers, for example :

server:
  coordinatorExtraNodeConfig: |
    node.id=trino-coordinator-XcaXd
  workerExtraNodeConfig: |
    node.id=${ENV:HOSTNAME}

Thanks.
