### PR TITLE
Add catalogsConfigmapOverride

### DIFF
--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -59,7 +59,11 @@ Create chart name and version as used by the chart label.
 
 
 {{- define "trino.catalog" -}}
+{{- if .Values.catalogsConfigmapOverride }}
+{{- .Values.catalogsConfigmapOverride }}
+{{- else }}
 {{ template "trino.fullname" . }}-catalog
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/trino/templates/configmap-catalog.yaml
+++ b/charts/trino/templates/configmap-catalog.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.catalogsConfigmapOverride }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,6 +19,7 @@ data:
 {{- range $catalogName, $catalogProperties := .Values.additionalCatalogs }}
   {{ $catalogName }}.properties: |
     {{- $catalogProperties | nindent 4 }}
+{{- end }}
 {{- end }}
 
 

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -105,6 +105,9 @@ additionalExchangeManagerProperties: {}
 
 eventListenerProperties: {}
 
+# need either one of catalogsConfigmapOverride or additionalCatalogs
+# catalogsConfigmapOverride will take precedence if both exists
+catalogsConfigmapOverride: ""
 additionalCatalogs: {}
 
 # Array of EnvVar (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core)


### PR DESCRIPTION
This to provide ability to use our own configmap for the catalogs instead of adding the catalogs inline in the values.yaml, for example :

catalogsConfigmapOverride: my-trino-catalog-configmap

Thanks.
