### PR TITLE
feat: :sparkles: Added Lifecycle Hook and Termination Grace Period 

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -63,6 +63,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.resources` |  | `{}` |
 | `coordinator.livenessProbe` |  | `{}` |
 | `coordinator.readinessProbe` |  | `{}` |
+| `coordinator.lifecycle` |  | `{}` |
+| `coordinator.terminationGracePeriodSeconds` |  | `30` |
 | `coordinator.nodeSelector` |  | `{}` |
 | `coordinator.tolerations` |  | `[]` |
 | `coordinator.affinity` |  | `{}` |
@@ -79,6 +81,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.resources` |  | `{}` |
 | `worker.livenessProbe` |  | `{}` |
 | `worker.readinessProbe` |  | `{}` |
+| `worker.lifecycle` |  | `{}` |
+| `worker.terminationGracePeriodSeconds` |  | `30` |
 | `worker.nodeSelector` |  | `{}` |
 | `worker.tolerations` |  | `[]` |
 | `worker.affinity` |  | `{}` |

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -68,6 +68,7 @@ spec:
         {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.coordinator.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}-coordinator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -122,6 +123,8 @@ spec:
             timeoutSeconds: {{ .Values.coordinator.readinessProbe.timeoutSeconds | default 5 }}
             failureThreshold: {{ .Values.coordinator.readinessProbe.failureThreshold | default 6 }}
             successThreshold: {{ .Values.coordinator.readinessProbe.successThreshold | default 1 }}
+          lifecycle:
+            {{- toYaml .Values.coordinator.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.coordinator.resources | nindent 12 }}
       {{- with .Values.coordinator.nodeSelector }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -57,6 +57,7 @@ spec:
       {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -99,6 +100,8 @@ spec:
             timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds | default 5 }}
             failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold | default 6 }}
             successThreshold: {{ .Values.worker.readinessProbe.successThreshold | default 1 }}
+          lifecycle:
+            {{- toYaml .Values.worker.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
       {{- with .Values.worker.nodeSelector }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -192,6 +192,13 @@ coordinator:
     # failureThreshold: 6
     # successThreshold: 1
 
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "sleep 120"]
+
+  terminationGracePeriodSeconds: 30
+
   nodeSelector: {}
 
   tolerations: []
@@ -246,6 +253,18 @@ worker:
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+  lifecycle: {}
+    # To enable Graceful shutdown, Define a lifecycle preStop like bellow,
+    # Set the `terminationGracePeriodSeconds` to a value greater than or equal to the configured `shutdown.grace-period`.
+    # Configure `shutdown.grace-period` in `additionalConfigProperties` as `shutdown.grace-period=2m` (default is 2 minutes).
+    # Allow the operation on `accessControl` because isn't allow by default.
+    # Check the documentaion on https://trino.io/docs/current/admin/graceful-shutdown.html
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "curl -v -X PUT -d '\"SHUTTING_DOWN\"' -H \"Content-type: application/json\" http://localhost:8081/v1/info/state"]
+
+  terminationGracePeriodSeconds: 30
 
   nodeSelector: {}
 


### PR DESCRIPTION
- Adding Lifecycle Hook
- Added Termination Grace Period 

Those features are intended to achieve the Graceful shutdown from Trino Worker nodes.
https://trino.io/docs/current/admin/graceful-shutdown.html#admin-graceful-shutdown

With `lifecycle hooks`, when the pods receive a SIGTERM will request the API to start the `SHUTTING_DOWN` state and the `terminationGracePeriodSeconds` is for K8s waiting for this process to be concluded.