### PR TITLE
Fix secretName usage under ingress.tls

### DIFF
--- a/charts/trino/templates/ingress.yaml
+++ b/charts/trino/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .Values.ingress.tls.secretName }}
+      secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:


### PR DESCRIPTION
The `.Values.ingress.tls` object is an array of objects and the `secretName` value was being referenced as though it were an object.