### PR TITLE
Add common labels to ingress and pods

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -30,6 +30,9 @@ spec:
         {{- if .Values.coordinator.labels }}
         {{- tpl (toYaml .Values.coordinator.labels) . | nindent 8 }}
         {{- end }}
+        {{- if .Values.commonLabels }}
+        {{- tpl (toYaml .Values.commonLabels) . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -34,6 +34,9 @@ spec:
         {{- if .Values.worker.labels }}
         {{- tpl (toYaml .Values.worker.labels) . | nindent 8 }}
         {{- end }}
+        {{- if .Values.commonLabels }}
+        {{- tpl (toYaml .Values.commonLabels) . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}

--- a/charts/trino/templates/ingress.yaml
+++ b/charts/trino/templates/ingress.yaml
@@ -7,6 +7,9 @@ metadata:
   name: {{ template "trino.coordinator" . }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
This is a follow-up PR to #90

1. Ingress was added in parallel with #90 so it doesn't have the commonLabels
2. In #90 commonLabels were added to the coordinator & worker deployment, but not the pods spawned from the deployments. Fixing that