### PR TITLE
Fix Server.ExtraConfig indentation

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -66,7 +66,7 @@ data:
     http-server.https.port={{ .Values.server.config.https.port }}
     http-server.https.keystore.path={{ .Values.server.config.https.keystore.path }}
   {{- end }}
-  {{ .Values.server.coordinatorExtraConfig | indent 4 }}
+  {{ .Values.server.coordinatorExtraConfig | indent 2 }}
 
 {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
   access-control.properties: |

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -54,7 +54,7 @@ data:
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
   {{- end }}
-  {{ .Values.server.workerExtraConfig | indent 4 }}
+  {{ .Values.server.workerExtraConfig | indent 2 }}
 
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}


### PR DESCRIPTION
Switch workerExtraConfig indentation to 2
Switch coordinatorExtraConfig indentation to 2

Before

    config.properties: |
    coordinator=true
    node-scheduler.include-coordinator=false
    http-server.http.port=8080
    query.max-memory=4GB
    query.max-memory-per-node=1GB
    discovery.uri=http://localhost:8080
      someKey=someValue


After

    config.properties: |
    coordinator=true
    node-scheduler.include-coordinator=false
    http-server.http.port=8080
    query.max-memory=4GB
    query.max-memory-per-node=1GB
    discovery.uri=http://localhost:8080
    someKey=someValue