### PR TITLE
Bump Trino version and fix jvm.config

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # Same value as in values.yml#image.tag
-appVersion: "423"
+appVersion: "432"
 
 icon: https://trino.io/assets/trino.png
 

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -13,7 +13,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | ------------------------ | ----------------------- | -------------- |
 | `image.repository` |  | `"trinodb/trino"` |
 | `image.pullPolicy` |  | `"IfNotPresent"` |
-| `image.tag` |  | `423` |
+| `image.tag` |  | `432` |
 | `imagePullSecrets` |  | `[{"name": "registry-credentials"}]` |
 | `server.workers` |  | `2` |
 | `server.node.environment` |  | `"production"` |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -22,21 +22,22 @@ data:
 
   jvm.config: |
     -server
+    -agentpath:/usr/lib/trino/bin/libjvmkill.so
     -Xmx{{ .Values.coordinator.jvm.maxHeapSize }}
     -XX:+{{ .Values.coordinator.jvm.gcMethod.type }}
     -XX:G1HeapRegionSize={{ .Values.coordinator.jvm.gcMethod.g1.heapRegionSize }}
-    -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
-    -Djdk.attach.allowAttachSelf=true
-    -XX:-UseBiasedLocking
+    -XX:-OmitStackTraceInFastThrow
     -XX:ReservedCodeCacheSize=512M
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
+    -Djdk.attach.allowAttachSelf=true
     -Djdk.nio.maxCachedBufferSize=2000000
     -XX:+UnlockDiagnosticVMOptions
-    -XX:+UseAESCTRIntrinsics
+    # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
+    -XX:GCLockerRetryAllocationCount=32
   {{- range $configValue := .Values.coordinator.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -23,21 +23,22 @@ data:
 
   jvm.config: |
     -server
+    -agentpath:/usr/lib/trino/bin/libjvmkill.so
     -Xmx{{ .Values.worker.jvm.maxHeapSize }}
     -XX:+{{ .Values.worker.jvm.gcMethod.type }}
     -XX:G1HeapRegionSize={{ .Values.worker.jvm.gcMethod.g1.heapRegionSize }}
-    -XX:+UseGCOverheadLimit
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
-    -Djdk.attach.allowAttachSelf=true
-    -XX:-UseBiasedLocking
+    -XX:-OmitStackTraceInFastThrow
     -XX:ReservedCodeCacheSize=512M
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
+    -Djdk.attach.allowAttachSelf=true
     -Djdk.nio.maxCachedBufferSize=2000000
     -XX:+UnlockDiagnosticVMOptions
-    -XX:+UseAESCTRIntrinsics
+    # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
+    -XX:GCLockerRetryAllocationCount=32
   {{- range $configValue := .Values.worker.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
   # Same value as Chart.yaml#appVersion
-  tag: 423
+  tag: 432
 
 imagePullSecrets:
   - name: registry-credentials


### PR DESCRIPTION
The default `jvm.config` was very outdated. It doesn't work with latest Trino, after it switched to Java 21, because `-XX:-UseBiasedLocking` is not recognized anymore.