### PR TITLE
Add support for additional user defined ConfigMaps

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -282,6 +282,15 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `serviceAccount.annotations` - object, default: `{}`  
 
   Annotations to add to the service account
+* `configMounts` - list, default: `[]`  
+
+  Allows mounting additional Trino configuration files from Kubernetes config maps on all nodes.
+  Example:
+  ```yaml
+   - name: sample-config-mount
+     configMap: sample-config-map
+     path: /config-map/sample.json
+  ```
 * `secretMounts` - list, default: `[]`  
 
   Allows mounting additional Trino configuration files from Kubernetes secrets on all nodes.
@@ -363,6 +372,15 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
      readOnly: true
 * `coordinator.annotations` - object, default: `{}`
 * `coordinator.labels` - object, default: `{}`
+* `coordinator.configMounts` - list, default: `[]`  
+
+  Allows mounting additional Trino configuration files from Kubernetes config maps on the coordinator node.
+  Example:
+  ```yaml
+   - name: sample-config-mount
+     configMap: sample-config-mount
+     path: /config-mount/sample.json
+  ```
 * `coordinator.secretMounts` - list, default: `[]`  
 
   Allows mounting additional Trino configuration files from Kubernetes secrets on the coordinator node.
@@ -444,6 +462,15 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
   ```
 * `worker.annotations` - object, default: `{}`
 * `worker.labels` - object, default: `{}`
+* `worker.configMounts` - list, default: `[]`  
+
+  Allows mounting additional Trino configuration files from Kubernetes config maps on all worker nodes.
+  Example:
+  ```yaml
+  - name: sample-config-mount
+    configMap: sample-config-mount
+    path: /config-mount/sample.json
+  ```
 * `worker.secretMounts` - list, default: `[]`  
 
   Allows mounting additional Trino configuration files from Kubernetes secrets on all worker nodes.

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -85,6 +85,16 @@ spec:
                 path: group.db
               {{- end }}
         {{- end }}
+        {{- range .Values.configMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
+        {{- range .Values.coordinator.configMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
@@ -129,6 +139,14 @@ spec:
             {{- if .Values.resourceGroups }}
             - mountPath: {{ .Values.server.config.path }}/resource-groups
               name: resource-groups-volume
+            {{- end }}
+            {{- range .Values.configMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+            {{- end }}
+            {{- range .Values.coordinator.configMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
             {{- end }}
             {{- range .Values.secretMounts }}
             - name: {{ .name }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -59,6 +59,16 @@ spec:
         - name: schemas-volume
           configMap:
             name: schemas-volume-worker
+        {{- range .Values.configMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
+        {{- range .Values.worker.configMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
@@ -96,6 +106,14 @@ spec:
               name: catalog-volume
             - mountPath: {{ .Values.kafka.mountPath }}
               name: schemas-volume
+            {{- range .Values.configMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+            {{- end }}
+            {{- range .Values.worker.configMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+            {{- end }}
             {{- range .Values.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -310,6 +310,17 @@ serviceAccount:
   # -- Annotations to add to the service account
   annotations: {}
 
+configMounts: []
+# configMounts -- Allows mounting additional Trino configuration files from
+# Kubernetes config maps on all nodes.
+# @raw
+# Example:
+# ```yaml
+#  - name: sample-config-mount
+#    configMap: sample-config-map
+#    path: /config-map/sample.json
+# ```
+
 secretMounts: []
 # secretMounts -- Allows mounting additional Trino configuration files from
 # Kubernetes secrets on all nodes.
@@ -423,6 +434,17 @@ coordinator:
   annotations: {}
 
   labels: {}
+
+  configMounts: []
+  # coordinator.configMounts -- Allows mounting additional Trino configuration
+  # files from Kubernetes config maps on the coordinator node.
+  # @raw
+  # Example:
+  # ```yaml
+  #  - name: sample-config-mount
+  #    configMap: sample-config-mount
+  #    path: /config-mount/sample.json
+  # ```
 
   secretMounts: []
   # coordinator.secretMounts -- Allows mounting additional Trino configuration
@@ -542,6 +564,17 @@ worker:
   annotations: {}
 
   labels: {}
+
+  configMounts: []
+  # worker.configMounts -- Allows mounting additional Trino configuration
+  # files from Kubernetes config maps on all worker nodes.
+  # @raw
+  # Example:
+  # ```yaml
+  # - name: sample-config-mount
+  #   configMap: sample-config-mount
+  #   path: /config-mount/sample.json
+  # ```
 
   secretMounts: []
   # worker.secretMounts -- Allows mounting additional Trino configuration


### PR DESCRIPTION
Presently the chart supports only user defined secret mounts. This PR adds support for additional user defined config mounts.

I am only just getting started with trino but my use case for this at the moment is to mount a truststore for certificate authentication that is provided as a cluster wide config map.