### PR TITLE
Support groups without password authentication

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -104,14 +104,14 @@ data:
     password-authenticator.name=file
     file.password-file={{ .Values.server.config.path }}/auth/password.db
   {{- end }}
-  {{- if .Values.auth.groups }}
+  {{- if .Values.auth.groups }}{{- if not (index .Values.coordinator.additionalConfigFiles "group-provider.properties") }}
   group-provider.properties: |
     group-provider.name=file
     file.group-file={{ .Values.server.config.path }}/auth/group.db
     {{- if .Values.auth.refreshPeriod }}
     file.refresh-period={{ .Values.auth.refreshPeriod }}
     {{- end }}
-  {{- end }}
+  {{- end }}{{- end }}
 
 {{ if .Values.eventListenerProperties }}
   event-listener.properties: |

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -103,6 +103,7 @@ data:
   password-authenticator.properties: |
     password-authenticator.name=file
     file.password-file={{ .Values.server.config.path }}/auth/password.db
+  {{- end }}
   {{- if .Values.auth.groups }}
   group-provider.properties: |
     group-provider.name=file
@@ -110,7 +111,6 @@ data:
     {{- if .Values.auth.refreshPeriod }}
     file.refresh-period={{ .Values.auth.refreshPeriod }}
     {{- end }}
-  {{- end }}
   {{- end }}
 
 {{ if .Values.eventListenerProperties }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -63,17 +63,19 @@ spec:
           configMap:
             name: trino-resource-groups-volume-coordinator
         {{- end }}
-        {{- if contains "PASSWORD" .Values.server.config.authenticationType }}
-        - name: password-volume
+        {{- if or .Values.auth.passwordAuth .Values.auth.groups }}
+        - name: file-authentication-volume
           secret:
             {{- if and .Values.auth .Values.auth.passwordAuthSecret }}
             secretName: {{ .Values.auth.passwordAuthSecret }}
             {{- else }}
-            secretName: trino-password-authentication
+            secretName: trino-file-authentication
             {{- end }}
             items:
+              {{- if .Values.auth.passwordAuth }}
               - key: password.db
                 path: password.db
+              {{- end }} 
               {{- if .Values.auth.groups }}
               - key: group.db
                 path: group.db
@@ -129,9 +131,9 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .path }}
             {{- end }}
-            {{- if contains "PASSWORD" .Values.server.config.authenticationType }}
+            {{- if or .Values.auth.passwordAuth .Values.auth.groups }}
             - mountPath: {{ .Values.server.config.path }}/auth
-              name: password-volume
+              name: file-authentication-volume
             {{- end }}
             {{- with .Values.coordinator.additionalVolumeMounts }}
             {{- . | toYaml | nindent 12 }}

--- a/charts/trino/templates/secret.yaml
+++ b/charts/trino/templates/secret.yaml
@@ -1,19 +1,19 @@
-{{- if contains "PASSWORD" .Values.server.config.authenticationType }}
-{{- if .Values.auth.passwordAuth -}}
+{{- if or .Values.auth.passwordAuth .Values.auth.groups }}
 apiVersion: v1
 kind: Secret
 metadata:
   {{- if and .Values.auth .Values.auth.passwordAuthSecret }}
   name: {{ .Values.auth.passwordAuthSecret }}
   {{- else }}
-  name: trino-password-authentication
+  name: trino-file-authentication
   {{- end }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}
 data:
+{{- if .Values.auth.passwordAuth }}
   password.db: {{ .Values.auth.passwordAuth | b64enc }}
-  {{- if .Values.auth.groups}}
+{{- end }}
+{{- if .Values.auth.groups}}
   group.db: {{ .Values.auth.groups | b64enc }}
-  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Presently the chart only supports groups where password authentication is used.

This removes the limitation so that groups can be used with any authentication type. My specific use case is to enable groups with certificate authentication. However, I've also found it beneficial to be able to set groups with no authentication which has been helpful for testing.