### PR TITLE
When the pod starts, add host aliases to the /etc/hosts file

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `serviceAccount.name` |  | `""` |
 | `serviceAccount.annotations` |  | `{}` |
 | `secretMounts` |  | `[]` |
+| `hostAliases` | Additional host aliases | `[]` |
 | `coordinator.jvm.maxHeapSize` |  | `"8G"` |
 | `coordinator.jvm.gcMethod.type` |  | `"UseG1GC"` |
 | `coordinator.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |

--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -92,3 +92,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the hostaliases
+*/}}
+{{- define "trino.hostAliases" -}}
+hostAliases:
+{{- range .Values.hostaliases }}
+- ip: {{ .ip }}
+  hostnames:
+  {{- range .hostnames }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -34,6 +34,9 @@ spec:
         {{- tpl (toYaml .Values.commonLabels) . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hostAliases }}
+      {{- include "trino.hostAliases" . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}
       securityContext:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -38,6 +38,9 @@ spec:
         {{- tpl (toYaml .Values.commonLabels) . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hostAliases }}
+      {{- include "trino.hostAliases" . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}
       securityContext:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -174,7 +174,7 @@ secretMounts: []
   #   secretName: sample-secret
   #   path: /secrets/sample.json
 
-hostAliases: []
+hostAliases: []  # Additional host aliases
 # When the pod starts, add the following host aliases to the /etc/hosts file
 # - ip: "127.0.0.1"
 #   hostnames:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -174,6 +174,17 @@ secretMounts: []
   #   secretName: sample-secret
   #   path: /secrets/sample.json
 
+hostAliases: []
+# When the pod starts, add the following host aliases to the /etc/hosts file
+# - ip: "127.0.0.1"
+#   hostnames:
+#     - "localhost"
+#     - "test-datanode-01"
+# - ip: "127.0.0.1"
+#   hostnames:
+#     - "localhost"
+#     - "test-datanode-01"
+
 coordinator:
   jvm:
     maxHeapSize: "8G"


### PR DESCRIPTION
When trino needs to access multiple clusters, the hosts for external cluster interactions need to be added to the /etc/hosts file, otherwise the IP of domain name format may not be reachable. Therefore, I added this feature to add the specified host aliases to the /etc/hosts file when the pod starts.