### PR TITLE
Add configmap checksums for automatically roll deployments

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -18,11 +18,13 @@ spec:
       release: {{ .Release.Name }}
       component: coordinator
   template:
-    metadata:
-      {{- if .Values.coordinator.annotations }}
+    metadata:      
       annotations:
-      {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
-      {{- end }}
+        checksum/catalog-config: {{ include (print $.Template.BasePath "configmap-catalog.yaml") . | sha256sum }}
+        checksum/coordinator-config: {{ include (print $.Template.BasePath "configmap-coordinator.yaml") . | sha256sum }}
+        {{- if .Values.coordinator.annotations }}
+          {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "trino.name" . }}
         release: {{ .Release.Name }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -20,8 +20,8 @@ spec:
   template:
     metadata:      
       annotations:
-        checksum/catalog-config: {{ include (print $.Template.BasePath "configmap-catalog.yaml") . | sha256sum }}
-        checksum/coordinator-config: {{ include (print $.Template.BasePath "configmap-coordinator.yaml") . | sha256sum }}
+        checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}
         {{- if .Values.coordinator.annotations }}
           {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
         {{- end }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- if .Values.worker.annotations }}
       annotations:
-        checksum/coordinator-config: {{ include (print $.Template.BasePath "configmap-worker.yaml") . | sha256sum }}
+        checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
       {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       {{- if .Values.worker.annotations }}
       annotations:
-        checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
+        checksum/worker-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
       {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -25,6 +25,7 @@ spec:
     metadata:
       {{- if .Values.worker.annotations }}
       annotations:
+        checksum/coordinator-config: {{ include (print $.Template.BasePath "configmap-worker.yaml") . | sha256sum }}
       {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Add configmap checksum for automatically roll deployments on coordinator and worker: 
- `depolyment-coordinator` : `configmap-catalog.yaml` & `configmap-coordinator.yaml`
- `deployment-worker` : `configmap-worker.yaml`