### PR TITLE
Add configmap checksum on deployments

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -19,14 +19,14 @@ spec:
       release: {{ .Release.Name }}
       component: coordinator
   template:
-    metadata:      
+    metadata:
       annotations:
         checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
         checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}
       {{- if .Values.coordinator.annotations }}
       {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
       {{- end }}
-      
+
       labels:
         app: {{ template "trino.name" . }}
         release: {{ .Release.Name }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -19,11 +19,14 @@ spec:
       release: {{ .Release.Name }}
       component: coordinator
   template:
-    metadata:
-      {{- if .Values.coordinator.annotations }}
+    metadata:      
       annotations:
+        checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}
+      {{- if .Values.coordinator.annotations }}
       {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
       {{- end }}
+      
       labels:
         app: {{ template "trino.name" . }}
         release: {{ .Release.Name }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       {{- if .Values.worker.annotations }}
       annotations:
+        checksum/worker-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
       {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -24,9 +24,9 @@ spec:
       component: worker
   template:
     metadata:
-      {{- if .Values.worker.annotations }}
       annotations:
         checksum/worker-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
+      {{- if .Values.worker.annotations }}
       {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Add configmap checksum for automatically roll deployments on coordinator and worker: 
- `depolyment-coordinator` : `configmap-catalog.yaml` & `configmap-coordinator.yaml`
- `deployment-worker` : `configmap-worker.yaml`