### PR TITLE
Add additionalVolumes and additionalVolumeMounts to coordinator and worker

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -72,6 +72,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `coordinator.tolerations` |  | `[]` |
 | `coordinator.affinity` |  | `{}` |
 | `coordinator.additionalConfigFiles` |  | `{}` |
+| `coordinator.additionalVolumes` | One or more additional volumes to add to the coordinator. | `[]` |
+| `coordinator.additionalVolumeMounts` | One or more additional volume mounts to add to the coordinator. | `[]` |
 | `coordinator.annotations` |  | `{}` |
 | `coordinator.labels` |  | `{}` |
 | `coordinator.secretMounts` |  | `[]` |
@@ -89,6 +91,8 @@ The following table lists the configurable parameters of the Trino chart and the
 | `worker.tolerations` |  | `[]` |
 | `worker.affinity` |  | `{}` |
 | `worker.additionalConfigFiles` |  | `{}` |
+| `worker.additionalVolumes` | One or more additional volume mounts to add to all workers. | `[]` |
+| `worker.additionalVolumeMounts` | One or more additional volume mounts to add to all workers. | `[]` |
 | `worker.annotations` |  | `{}` |
 | `worker.labels` |  | `{}` |
 | `worker.secretMounts` |  | `[]` |

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -89,6 +89,9 @@ spec:
           secret:
             secretName: {{ .secretName }}
         {{- end }}
+        {{- with .Values.coordinator.additionalVolumes }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       {{- if .Values.initContainers.coordinator }}
       initContainers:
       {{- tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
@@ -129,6 +132,9 @@ spec:
             {{- if eq .Values.server.config.authenticationType "PASSWORD" }}
             - mountPath: {{ .Values.server.config.path }}/auth
               name: password-volume
+            {{- end }}
+            {{- with .Values.coordinator.additionalVolumeMounts }}
+            {{- . | toYaml | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -67,6 +67,9 @@ spec:
           secret:
             secretName: {{ .secretName }}
         {{- end }}
+        {{- with .Values.worker.additionalVolumes }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       {{- if .Values.initContainers.worker }}
       initContainers:
       {{- tpl (toYaml .Values.initContainers.worker) . | nindent 6 }}
@@ -95,6 +98,9 @@ spec:
             {{- range .Values.worker.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+            {{- end }}
+            {{- with .Values.worker.additionalVolumeMounts }}
+            {{- . | toYaml | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -302,6 +302,15 @@ coordinator:
 
   additionalConfigFiles: {}
 
+  additionalVolumes: []  # One or more additional volumes to add to the coordinator.
+    # - name: extras
+    #   emptyDir: {}
+
+  additionalVolumeMounts: []  # One or more additional volume mounts to add to the coordinator.
+    # - name: extras
+    #   mountPath: /usr/share/extras
+    #   readOnly: true
+
   annotations: {}
 
   labels: {}
@@ -361,6 +370,15 @@ worker:
   affinity: {}
 
   additionalConfigFiles: {}
+
+  additionalVolumes: []  # One or more additional volume mounts to add to all workers.
+    # - name: extras
+    #   emptyDir: {}
+
+  additionalVolumeMounts: []  # One or more additional volume mounts to add to all workers.
+    # - name: extras
+    #   mountPath: /usr/share/extras
+    #   readOnly: true
 
   annotations: {}
 


### PR DESCRIPTION
### Purpose

This change will allow the chart to take in the additional volume configurations for the coordinator and the worker.

For my use case, this is desired to authenticate the Trino Pods to a GCP project using workload identity federation.
ref) https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#deploy

Others seem to be interested in mounting emptyDirs etc (see Related PRs).

### Related PRs

- https://github.com/trinodb/charts/pull/73
- https://github.com/trinodb/charts/pull/76