### PR TITLE
Support service annotations

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -295,6 +295,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
   A list of the Linux kernel capabilities that are dropped from every container. Valid values are listed at https://man7.org/linux/man-pages/man7/capabilities.7.html Ensure to remove the "CAP_" prefix which the kernel attaches to the names of permissions.
 * `shareProcessNamespace.coordinator` - bool, default: `false`
 * `shareProcessNamespace.worker` - bool, default: `false`
+* `service.annotations` - object, default: `{}`
 * `service.type` - string, default: `"ClusterIP"`
 * `service.port` - int, default: `8080`
 * `auth` - object, default: `{}`  

--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -11,6 +11,8 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- tpl (toYaml .Values.commonLabels) . | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -332,6 +332,7 @@ shareProcessNamespace:
   worker: false
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 8080
 

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -18,6 +18,10 @@ additionalConfigProperties:
   - http-server.authentication.allow-insecure-over-http=true
   - http-server.process-forwarded=true
 
+service:
+  annotations:
+    custom/name: value
+
 auth:
   # created using htpasswd -B -C 10 password.db admin
   # every password is admin123


### PR DESCRIPTION
Enables the user to add annotations for the service resource so it can be integrated with load balancers and others.

This is a similar PR to https://github.com/trinodb/charts/pull/54 and aims to resolve the long-standing issue https://github.com/trinodb/trino/issues/13085, however as the PR hasn't had any progress in almost a year, trying to push through separately.