### PR TITLE
Added more options for specifying the container image

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -15,7 +15,7 @@ The following table lists the configurable parameters of the Trino chart and the
 | `image.repository` | Repository location of the Trino image, typically `organization/imagename` | `"trinodb/trino"` |
 | `image.tag` | Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml | `""` |
 | `image.digest` | Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`. | `""` |
-| `image.useRepositoryAsSoleImageReference` | When true, only the content in `repository` will be used as image reference | `false` |
+| `image.useRepositoryAsSoleImageReference` | When true, only the content in `repository` is used as image reference | `false` |
 | `image.pullPolicy` |  | `"IfNotPresent"` |
 | `imagePullSecrets` |  | `[{"name": "registry-credentials"}]` |
 | `server.workers` |  | `2` |

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -11,9 +11,11 @@ The following table lists the configurable parameters of the Trino chart and the
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `image.repository` |  | `"trinodb/trino"` |
+| `image.registry` | Trino image registry | `""` |
+| `image.repository` | Trino image repository | `"trinodb/trino"` |
+| `image.tag` | Trino image tag. Default is appVersion from Chart.yaml | `""` |
+| `image.digest` | Trino image digest as `sha256:abcd...`. Please note this parameter, if set, will override the tag | `""` |
 | `image.pullPolicy` |  | `"IfNotPresent"` |
-| `image.tag` |  | `432` |
 | `imagePullSecrets` |  | `[{"name": "registry-credentials"}]` |
 | `server.workers` |  | `2` |
 | `server.node.environment` |  | `"production"` |

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -11,10 +11,11 @@ The following table lists the configurable parameters of the Trino chart and the
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `image.registry` | Trino image registry | `""` |
-| `image.repository` | Trino image repository | `"trinodb/trino"` |
-| `image.tag` | Trino image tag. Default is appVersion from Chart.yaml | `""` |
-| `image.digest` | Trino image digest as `sha256:abcd...`. Please note this parameter, if set, will override the tag | `""` |
+| `image.registry` | Image registry, defaults to empty, which results in DockerHub usage | `""` |
+| `image.repository` | Repository location of the Trino image, typically `organization/imagename` | `"trinodb/trino"` |
+| `image.tag` | Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml | `""` |
+| `image.digest` | Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`. | `""` |
+| `image.useRepositoryAsSoleImageReference` | When true, only the content in `repository` will be used as image reference | `false` |
 | `image.pullPolicy` |  | `"IfNotPresent"` |
 | `imagePullSecrets` |  | `[{"name": "registry-credentials"}]` |
 | `server.workers` |  | `2` |

--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -92,3 +92,26 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the proper image name
+{{ include "trino.image" . }}
+
+Code is inspired from bitnami/common
+
+*/}}
+{{- define "trino.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := (default .Chart.AppVersion .Values.image.tag) | toString -}}
+{{- if .Values.image.digest }}
+  {{- $separator = "@" -}}
+  {{- $termination = .Values.image.digest | toString -}}
+{{- end -}}
+{{- if $registryName }}
+  {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+  {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
+{{- end -}}

--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -101,17 +101,22 @@ Code is inspired from bitnami/common
 
 */}}
 {{- define "trino.image" -}}
-{{- $registryName := .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $separator := ":" -}}
-{{- $termination := (default .Chart.AppVersion .Values.image.tag) | toString -}}
-{{- if .Values.image.digest }}
-  {{- $separator = "@" -}}
-  {{- $termination = .Values.image.digest | toString -}}
-{{- end -}}
-{{- if $registryName }}
-  {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- if .Values.image.useRepositoryAsSoleImageReference -}}
+  {{- printf "%s" $repositoryName -}}
 {{- else -}}
-  {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+  {{- $repositoryName := .Values.image.repository -}}
+  {{- $registryName := .Values.image.registry -}}
+  {{- $separator := ":" -}}
+  {{- $termination := (default .Chart.AppVersion .Values.image.tag) | toString -}}
+  {{- if .Values.image.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .Values.image.digest | toString -}}
+  {{- end -}}
+  {{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+  {{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -97,7 +97,7 @@ spec:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-coordinator
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "trino.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.env | nindent 12 }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -75,7 +75,7 @@ spec:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "trino.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.env | nindent 12 }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   registry: ""   # Trino image registry
-  repository: trinodb/trino    # Trind image repository
+  repository: trinodb/trino    # Trino image repository
   # Overrides the image tag whose default is the chart version.
   # Same value as Chart.yaml#appVersion
   tag: ""   # Trino image tag. Default is appVersion from Chart.yaml

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -7,6 +7,7 @@ image:
   repository: trinodb/trino    # Repository location of the Trino image, typically `organization/imagename`
   tag: ""   # Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
   digest: ""   # Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
+  useRepositoryAsSoleImageReference: false  # When true, only the content in `repository` will be used as image reference
   pullPolicy: IfNotPresent
 
 imagePullSecrets:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -3,12 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: ""   # Trino image registry
-  repository: trinodb/trino    # Trino image repository
-  # Overrides the image tag whose default is the chart version.
-  # Same value as Chart.yaml#appVersion
-  tag: ""   # Trino image tag. Default is appVersion from Chart.yaml
-  digest: ""   # Trino image digest as `sha256:abcd...`. Please note this parameter, if set, will override the tag
+  registry: ""   # Image registry, defaults to empty, which results in DockerHub usage
+  repository: trinodb/trino    # Repository location of the Trino image, typically `organization/imagename`
+  tag: ""   # Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
+  digest: ""   # Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
   pullPolicy: IfNotPresent
 
 imagePullSecrets:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -3,11 +3,13 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: trinodb/trino
-  pullPolicy: IfNotPresent
+  registry: ""   # Trino image registry
+  repository: trinodb/trino    # Trind image repository
   # Overrides the image tag whose default is the chart version.
   # Same value as Chart.yaml#appVersion
-  tag: 432
+  tag: ""   # Trino image tag. Default is appVersion from Chart.yaml
+  digest: ""   # Trino image digest as `sha256:abcd...`. Please note this parameter, if set, will override the tag
+  pullPolicy: IfNotPresent
 
 imagePullSecrets:
   - name: registry-credentials

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -7,7 +7,7 @@ image:
   repository: trinodb/trino    # Repository location of the Trino image, typically `organization/imagename`
   tag: ""   # Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
   digest: ""   # Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
-  useRepositoryAsSoleImageReference: false  # When true, only the content in `repository` will be used as image reference
+  useRepositoryAsSoleImageReference: false  # When true, only the content in `repository` is used as image reference
   pullPolicy: IfNotPresent
 
 imagePullSecrets:


### PR DESCRIPTION
We are using both a custom image registry (for caching/mirroring) and pinning the images using the image digest (instead of tag).

This pull request adds support for both custom registry and using a digest, and is backwards compatible with the current model. The actual code are inspired of the bitnami/common helm-chart.

The chart README.md file is not updated, as I assume it is regenerated in the CI/CD pipeline.

