### PR TITLE
service nodeport support

### DIFF
--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -12,6 +12,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}    
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -226,6 +226,7 @@ shareProcessNamespace:
 service:
   type: ClusterIP
   port: 8080
+  nodePort: ~
 
 auth: {}
   # Set username and password


### PR DESCRIPTION
There is no specific nodeport support for the trino service. I add support for specific nodeport.    