### PR TITLE
Add annotations templating for service

### DIFF
--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ template "trino.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -226,6 +226,7 @@ shareProcessNamespace:
 service:
   type: ClusterIP
   port: 8080
+  annotations: {}
 
 auth: {}
   # Set username and password

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -245,7 +245,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-  # Annotations for the service account
+  # Annotations decorating the service account
   annotations: {}
 
 secretMounts: []

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -245,7 +245,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-  # Annotations to add to the service account
+  # Annotations for the service account
   annotations: {}
 
 secretMounts: []


### PR DESCRIPTION
Primarily to support Load Balancer annotations in AWS, which are defined here. 
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/

Here are some examples, from within the charts/trino directory:

```
helm template . -f values.yaml | grep "kind: Service" -A 20 -B 3

---
# Source: trino/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-trino
  namespace: default
  labels:
    app: trino
    chart: trino-0.19.0
    release: release-name
    heritage: Helm
spec:
  type: ClusterIP
  ports:
    - port: 8080
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app: trino
    release: release-name
    component: coordinator
---
```

And with some annotations set:
```
helm template . -f values.yaml --set service.annotations.foo=boo --set service.annotations.bar=baz | grep "kind: Service" -A 23 -B 3 

---
# Source: trino/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-trino
  namespace: default
  labels:
    app: trino
    chart: trino-0.19.0
    release: release-name
    heritage: Helm
  annotations:
    bar: baz
    foo: boo
spec:
  type: ClusterIP
  ports:
    - port: 8080
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app: trino
    release: release-name
    component: coordinator
---
```

In practice this would be combined with `type: LoadBalancer`, but the addition of annotations does not itself require this use case so it would be unnecessary to restrict it.