### PR TITLE
additional volume and volume mount is not working

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -92,9 +92,7 @@ spec:
           secret:
             secretName: {{ .secretName }}
         {{- end }}
-        {{- with .Values.coordinator.additionalVolumes }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
+        {{- toYaml .Values.coordinator.additionalVolumes | nindent 8 }}
       {{- if .Values.initContainers.coordinator }}
       initContainers:
       {{- tpl (toYaml .Values.initContainers.coordinator) . | nindent 6 }}
@@ -136,9 +134,7 @@ spec:
             - mountPath: {{ .Values.server.config.path }}/auth
               name: file-authentication-volume
             {{- end }}
-            {{- with .Values.coordinator.additionalVolumeMounts }}
-            {{- . | toYaml | nindent 12 }}
-            {{- end }}
+            {{- toYaml .Values.coordinator.additionalVolumeMounts | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -68,9 +68,7 @@ spec:
           secret:
             secretName: {{ .secretName }}
         {{- end }}
-        {{- with .Values.worker.additionalVolumes }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
+        {{- toYaml .Values.coordinator.additionalVolumes | nindent 8 }}
       {{- if .Values.initContainers.worker }}
       initContainers:
       {{- tpl (toYaml .Values.initContainers.worker) . | nindent 6 }}
@@ -100,9 +98,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .path }}
             {{- end }}
-            {{- with .Values.worker.additionalVolumeMounts }}
-            {{- . | toYaml | nindent 12 }}
-            {{- end }}
+            {{- toYaml .Values.coordinator.additionalVolumeMounts | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
I checked and additionalVolumes and additionalVolumeMounts option of coordinator and worker is not working. After these changes, I can see the volumes and volumeMounts in `helm template`.