### PR TITLE
add forgotten namespace to resourceGroups manifest

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -152,6 +152,7 @@ metadata:
   name: trino-resource-groups-volume-coordinator
   labels:
     {{- include "trino.labels" . | nindent 4 }}
+    namespace: {{ .Release.Namespace }}
     app.kubernetes.io/component: coordinator
 data:
   resource-groups.json: |- 


### PR DESCRIPTION
add forgotten namespace when #115 was merged, @losipiuk PTAL 