### PR TITLE
Replace frigate with helm-docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -60,28 +60,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install Frigate
-        run: pip install frigate
-      - name: Check if chart README is in-sync
-        run: |
-          frigate gen charts/trino > charts/trino/README.md
-          if ! git diff --exit-code --quiet; then
-            cat << 'EOF'
-          charts/trino/README.md is not in sync with chart
-          Please update charts/trino/README.md by running:
-              python3 -m venv .venv && . .venv/bin/activate
-              pip install frigate
-              frigate gen charts/trino > charts/trino/README.md
-
-          Here's a diff of what's changed:
-          EOF
-
-            git diff
-            # fail the job
-            exit 1
-          else
-            echo "charts/trino/README.md is in-sync with chart"
-          fi
+      - uses: pre-commit/action@v3.0.1
 
   # Everything above is CI, everything here and below is for releases and runs only on non-pull-request events
   sync-readme:

--- a/.helmignore
+++ b/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+# helm-doc template
+README.md.gotmpl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+- repo: https://github.com/norwoodj/helm-docs
+  rev:  v1.13.1
+  hooks:
+  - id: helm-docs-container
+    args:
+    - --chart-search-root=charts
+    - --document-dependency-values

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
   rev: v4.5.0
   hooks:
   - id: trailing-whitespace
+    args:
+    - --markdown-linebreak-ext=md
   - id: end-of-file-fixer
 - repo: https://github.com/norwoodj/helm-docs
   rev:  v1.13.1
@@ -11,3 +13,4 @@ repos:
     args:
     - --chart-search-root=charts
     - --document-dependency-values
+    - --sort-values-order=file

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ You can find documentation about the chart [here](./charts/trino/README.md).
 
 ## Development
 
+To test the chart, install it into a Kubernetes cluster. Use `kind` to create a
+Kubernetes cluster running in a container, and `chart-testing` to install the
+chart and run [tests](charts/trino/templates/tests).
+
+```console
+brew install helm kind chart-testing
+kind create cluster
+ct install
+```
+
+To run tests with specific values:
+```console
+ct install --helm-extra-set-args "--set image.tag=448"
+```
+
 The documentation is automatically generated from the chart files. Install a
 git hook to have it automatically updated when committing changes. Make sure
 you [install the pre-commit binary](https://pre-commit.com/#install), then run:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ To run tests with specific values:
 ct install --helm-extra-set-args "--set image.tag=448"
 ```
 
+Use the `test.sh` script to run a suite of tests, with different chart values.
+If some of the tests fail, use the `-s` flag to skip cleanup and inspect the
+resources installed in the Kubernetes cluster. Use `-n` to use a specific
+namespace, not a randomly generated one. Use `-t` to run only selected tests.
+See the command help (`-h`) for a list of available tests.
+
+Example:
+```console
+./test.sh -n trino -s -t default
+```
+
 The documentation is automatically generated from the chart files. Install a
 git hook to have it automatically updated when committing changes. Make sure
 you [install the pre-commit binary](https://pre-commit.com/#install), then run:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then you can install chart using:
 helm install my-trino trino/trino --version 0.21.0
 ```
 
-Also, you can check the manifests using: 
+Also, you can check the manifests using:
 
 ```console
 helm template my-trino trino/trino --namespace <YOUR_NAMESPACE>
@@ -34,3 +34,14 @@ helm template my-trino trino/trino --namespace <YOUR_NAMESPACE>
 ## Documentation
 
 You can find documentation about the chart [here](./charts/trino/README.md).
+
+## Development
+
+The documentation is automatically generated from the chart files. Install a
+git hook to have it automatically updated when committing changes. Make sure
+you [install the pre-commit binary](https://pre-commit.com/#install), then run:
+
+```console
+pre-commit install
+pre-commit install-hooks
+```

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 446](https://img.shields.io/badge/AppVersion-446-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 448](https://img.shields.io/badge/AppVersion-448-informational?style=flat-square)
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe
 
@@ -12,109 +12,494 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * <https://github.com/trinodb/trino/tree/master/core/docker>
 
 ## Values
+* `image.registry` - string, default: `""`  
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| accessControl | object | `{}` |  |
-| additionalCatalogs | object | `{}` |  |
-| additionalConfigProperties | object | `{}` |  |
-| additionalExchangeManagerProperties | object | `{}` |  |
-| additionalLogProperties | object | `{}` |  |
-| additionalNodeProperties | object | `{}` |  |
-| auth | object | `{}` |  |
-| commonLabels | object | `{}` |  |
-| coordinator.additionalConfigFiles | object | `{}` |  |
-| coordinator.additionalExposedPorts | object | `{}` |  |
-| coordinator.additionalJVMConfig | list | `[]` |  |
-| coordinator.additionalVolumeMounts | list | `[]` |  |
-| coordinator.additionalVolumes | list | `[]` |  |
-| coordinator.affinity | object | `{}` |  |
-| coordinator.annotations | object | `{}` |  |
-| coordinator.config.memory.heapHeadroomPerNode | string | `""` |  |
-| coordinator.config.query.maxMemoryPerNode | string | `"1GB"` |  |
-| coordinator.jvm.gcMethod.g1.heapRegionSize | string | `"32M"` |  |
-| coordinator.jvm.gcMethod.type | string | `"UseG1GC"` |  |
-| coordinator.jvm.maxHeapSize | string | `"8G"` |  |
-| coordinator.labels | object | `{}` |  |
-| coordinator.lifecycle | object | `{}` |  |
-| coordinator.livenessProbe | object | `{}` |  |
-| coordinator.nodeSelector | object | `{}` |  |
-| coordinator.readinessProbe | object | `{}` |  |
-| coordinator.resources | object | `{}` |  |
-| coordinator.secretMounts | list | `[]` |  |
-| coordinator.terminationGracePeriodSeconds | int | `30` |  |
-| coordinator.tolerations | list | `[]` |  |
-| env | list | `[]` |  |
-| envFrom | list | `[]` |  |
-| eventListenerProperties | object | `{}` |  |
-| image.digest | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `""` |  |
-| image.repository | string | `"trinodb/trino"` |  |
-| image.tag | string | `""` |  |
-| image.useRepositoryAsSoleImageReference | bool | `false` |  |
-| imagePullSecrets[0].name | string | `"registry-credentials"` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.className | string | `""` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.hosts | list | `[]` |  |
-| ingress.tls | list | `[]` |  |
-| initContainers | object | `{}` |  |
-| kafka.mountPath | string | `"/etc/trino/schemas"` |  |
-| kafka.tableDescriptions | object | `{}` |  |
-| resourceGroups | object | `{}` |  |
-| secretMounts | list | `[]` |  |
-| securityContext.runAsGroup | int | `1000` |  |
-| securityContext.runAsUser | int | `1000` |  |
-| server.autoscaling.behavior | object | `{}` |  |
-| server.autoscaling.enabled | bool | `false` |  |
-| server.autoscaling.maxReplicas | int | `5` |  |
-| server.autoscaling.targetCPUUtilizationPercentage | int | `50` |  |
-| server.config.authenticationType | string | `""` |  |
-| server.config.http.port | int | `8080` |  |
-| server.config.https.enabled | bool | `false` |  |
-| server.config.https.keystore.path | string | `""` |  |
-| server.config.https.port | int | `8443` |  |
-| server.config.path | string | `"/etc/trino"` |  |
-| server.config.query.maxMemory | string | `"4GB"` |  |
-| server.coordinatorExtraConfig | string | `""` |  |
-| server.exchangeManager.baseDir | string | `"/tmp/trino-local-file-system-exchange-manager"` |  |
-| server.exchangeManager.name | string | `"filesystem"` |  |
-| server.log.trino.level | string | `"INFO"` |  |
-| server.node.dataDir | string | `"/data/trino"` |  |
-| server.node.environment | string | `"production"` |  |
-| server.node.pluginDir | string | `"/usr/lib/trino/plugin"` |  |
-| server.workerExtraConfig | string | `""` |  |
-| server.workers | int | `2` |  |
-| service.port | int | `8080` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `false` |  |
-| serviceAccount.name | string | `""` |  |
-| shareProcessNamespace.coordinator | bool | `false` |  |
-| shareProcessNamespace.worker | bool | `false` |  |
-| sidecarContainers | object | `{}` |  |
-| worker.additionalConfigFiles | object | `{}` |  |
-| worker.additionalExposedPorts | object | `{}` |  |
-| worker.additionalJVMConfig | list | `[]` |  |
-| worker.additionalVolumeMounts | list | `[]` |  |
-| worker.additionalVolumes | list | `[]` |  |
-| worker.affinity | object | `{}` |  |
-| worker.annotations | object | `{}` |  |
-| worker.config.memory.heapHeadroomPerNode | string | `""` |  |
-| worker.config.query.maxMemoryPerNode | string | `"1GB"` |  |
-| worker.jvm.gcMethod.g1.heapRegionSize | string | `"32M"` |  |
-| worker.jvm.gcMethod.type | string | `"UseG1GC"` |  |
-| worker.jvm.maxHeapSize | string | `"8G"` |  |
-| worker.labels | object | `{}` |  |
-| worker.lifecycle | object | `{}` |  |
-| worker.livenessProbe | object | `{}` |  |
-| worker.nodeSelector | object | `{}` |  |
-| worker.readinessProbe | object | `{}` |  |
-| worker.resources | object | `{}` |  |
-| worker.secretMounts | list | `[]` |  |
-| worker.terminationGracePeriodSeconds | int | `30` |  |
-| worker.tolerations | list | `[]` |  |
+  Image registry, defaults to empty, which results in DockerHub usage
+* `image.repository` - string, default: `"trinodb/trino"`  
+
+  Repository location of the Trino image, typically `organization/imagename`
+* `image.tag` - string, default: `""`  
+
+  Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
+* `image.digest` - string, default: `""`  
+
+  Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
+* `image.useRepositoryAsSoleImageReference` - bool, default: `false`  
+
+  When true, only the content in `repository` is used as image reference
+* `image.pullPolicy` - string, default: `"IfNotPresent"`
+* `imagePullSecrets[0].name` - string, default: `"registry-credentials"`
+* `server.workers` - int, default: `2`
+* `server.node.environment` - string, default: `"production"`
+* `server.node.dataDir` - string, default: `"/data/trino"`
+* `server.node.pluginDir` - string, default: `"/usr/lib/trino/plugin"`
+* `server.log.trino.level` - string, default: `"INFO"`
+* `server.config.path` - string, default: `"/etc/trino"`
+* `server.config.http.port` - int, default: `8080`
+* `server.config.https.enabled` - bool, default: `false`
+* `server.config.https.port` - int, default: `8443`
+* `server.config.https.keystore.path` - string, default: `""`
+* `server.config.authenticationType` - string, default: `""`  
+
+  Trino supports multiple [authentication types](https://trino.io/docs/current/security/authentication-types.html): PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS.
+* `server.config.query.maxMemory` - string, default: `"4GB"`
+* `server.exchangeManager.name` - string, default: `"filesystem"`
+* `server.exchangeManager.baseDir` - string, default: `"/tmp/trino-local-file-system-exchange-manager"`
+* `server.workerExtraConfig` - string, default: `""`
+* `server.coordinatorExtraConfig` - string, default: `""`
+* `server.autoscaling.enabled` - bool, default: `false`
+* `server.autoscaling.maxReplicas` - int, default: `5`
+* `server.autoscaling.targetCPUUtilizationPercentage` - int, default: `50`
+* `server.autoscaling.behavior` - object, default: `{}`  
+
+  Configuration for scaling up and down.
+  Example:
+  ```yaml
+   scaleDown:
+     stabilizationWindowSeconds: 300
+     policies:
+     - type: Percent
+       value: 100
+       periodSeconds: 15
+   scaleUp:
+     stabilizationWindowSeconds: 0
+     policies:
+     - type: Percent
+       value: 100
+       periodSeconds: 15
+     - type: Pods
+       value: 4
+       periodSeconds: 15
+     selectPolicy: Max
+  ```
+* `accessControl` - object, default: `{}`  
+
+  [System access control](https://trino.io/docs/current/security/built-in-system-access-control.html) configuration.
+  Example:
+  ```yaml
+   type: configmap
+   refreshPeriod: 60s
+   # Rules file is mounted to /etc/trino/access-control
+   configFile: "rules.json"
+   rules:
+     rules.json: |-
+       {
+         "catalogs": [
+           {
+             "user": "admin",
+             "catalog": "(mysql|system)",
+             "allow": "all"
+           },
+           {
+             "group": "finance|human_resources",
+             "catalog": "postgres",
+             "allow": true
+           },
+           {
+             "catalog": "hive",
+             "allow": "all"
+           },
+           {
+             "user": "alice",
+             "catalog": "postgresql",
+             "allow": "read-only"
+           },
+           {
+             "catalog": "system",
+             "allow": "none"
+           }
+         ],
+         "schemas": [
+           {
+             "user": "admin",
+             "schema": ".*",
+             "owner": true
+           },
+           {
+             "user": "guest",
+             "owner": false
+           },
+           {
+             "catalog": "default",
+             "schema": "default",
+             "owner": true
+           }
+         ]
+       }
+  ```
+* `resourceGroups` - object, default: `{}`  
+
+  Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
+  Example:
+  ```yaml
+   resourceGroupsConfig: |-
+       {
+         "rootGroups": [
+           {
+             "name": "global",
+             "softMemoryLimit": "80%",
+             "hardConcurrencyLimit": 100,
+             "maxQueued": 100,
+             "schedulingPolicy": "fair",
+             "jmxExport": true,
+             "subGroups": [
+               {
+                 "name": "admin",
+                 "softMemoryLimit": "30%",
+                 "hardConcurrencyLimit": 20,
+                 "maxQueued": 10
+               },
+               {
+                 "name": "finance_human_resources",
+                 "softMemoryLimit": "20%",
+                 "hardConcurrencyLimit": 15,
+                 "maxQueued": 10
+               },
+               {
+                 "name": "general",
+                 "softMemoryLimit": "30%",
+                 "hardConcurrencyLimit": 20,
+                 "maxQueued": 10
+               },
+               {
+                 "name": "readonly",
+                 "softMemoryLimit": "10%",
+                 "hardConcurrencyLimit": 5,
+                 "maxQueued": 5
+               }
+             ]
+           }
+         ],
+         "selectors": [
+           {
+             "user": "admin",
+             "group": "global.admin"
+           },
+           {
+             "group": "finance|human_resources",
+             "group": "global.finance_human_resources"
+           },
+           {
+             "user": "alice",
+             "group": "global.readonly"
+           },
+           {
+             "group": "global.general"
+           }
+         ]
+       }
+  ```
+* `additionalNodeProperties` - object, default: `{}`
+* `additionalConfigProperties` - object, default: `{}`
+* `additionalLogProperties` - object, default: `{}`
+* `additionalExchangeManagerProperties` - object, default: `{}`
+* `eventListenerProperties` - object, default: `{}`
+* `additionalCatalogs` - object, default: `{}`
+* `env` - list, default: `[]`  
+
+  additional environment variables added to every pod, specified as a list with explicit values
+  Example:
+  ```yaml
+   - name: NAME
+     value: "value"
+  ```
+* `envFrom` - list, default: `[]`  
+
+  additional environment variables added to every pod, specified as a list of either ConfigMap or Secret references
+  Example:
+  ```yaml
+    - secretRef:
+      name: extra-secret
+  ```
+* `initContainers` - object, default: `{}`  
+
+  Additional [containers that run to completion](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) during pod initialization.
+  Example:
+  ```yaml
+   coordinator:
+     - name: init-coordinator
+       image: busybox:1.28
+       imagePullPolicy: IfNotPresent
+       command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+   worker:
+     - name: init-worker
+       image: busybox:1.28
+       command: ['sh', '-c', 'echo The worker is running! && sleep 3600']
+  ```
+* `sidecarContainers` - object, default: `{}`  
+
+  Additional [containers that starts before](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) the Trino container and continues to run.
+  Example:
+  ```yaml
+   coordinator:
+     - name: side-coordinator
+       image: busybox:1.28
+       imagePullPolicy: IfNotPresent
+       command: ['sleep', '1']
+   worker:
+     - name: side-worker
+       image: busybox:1.28
+       imagePullPolicy: IfNotPresent
+       command: ['sleep', '1']
+  ```
+* `securityContext.runAsUser` - int, default: `1000`
+* `securityContext.runAsGroup` - int, default: `1000`
+* `shareProcessNamespace.coordinator` - bool, default: `false`
+* `shareProcessNamespace.worker` - bool, default: `false`
+* `service.type` - string, default: `"ClusterIP"`
+* `service.port` - int, default: `8080`
+* `auth` - object, default: `{}`  
+
+  Available authentication methods.
+  Use username and password provided as a [password file](https://trino.io/docs/current/security/password-file.html#file-format):
+  ```yaml
+   passwordAuth: "username:encrypted-password-with-htpasswd"
+  ```
+  Set the name of a secret containing this file in the password.db key
+  ```yaml
+   passwordAuthSecret: "trino-password-authentication"
+  ```
+  Additionally, set [users' groups](https://trino.io/docs/current/security/group-file.html#file-format):
+  ```yaml
+   refreshPeriod: 5s
+   groups: "group_name:user_1,user_2,user_3"
+  ```
+* `serviceAccount.create` - bool, default: `false`  
+
+  Specifies whether a service account should be created
+* `serviceAccount.name` - string, default: `""`  
+
+  The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+* `serviceAccount.annotations` - object, default: `{}`  
+
+  Annotations to add to the service account
+* `secretMounts` - list, default: `[]`  
+
+  Allows mounting additional Trino configuration files from Kubernetes secrets on all nodes.
+  Example:
+  ```yaml
+   - name: sample-secret
+     secretName: sample-secret
+     path: /secrets/sample.json
+  ```
+* `coordinator.jvm.maxHeapSize` - string, default: `"8G"`
+* `coordinator.jvm.gcMethod.type` - string, default: `"UseG1GC"`
+* `coordinator.jvm.gcMethod.g1.heapRegionSize` - string, default: `"32M"`
+* `coordinator.config.memory.heapHeadroomPerNode` - string, default: `""`
+* `coordinator.config.query.maxMemoryPerNode` - string, default: `"1GB"`
+* `coordinator.additionalJVMConfig` - list, default: `[]`
+* `coordinator.additionalExposedPorts` - object, default: `{}`
+* `coordinator.resources` - object, default: `{}`  
+
+  It is recommended not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, use the following example, and adjust it as necessary.
+  Example:
+  ```yaml
+   limits:
+     cpu: 100m
+     memory: 128Mi
+   requests:
+     cpu: 100m
+     memory: 128Mi
+  ```
+* `coordinator.livenessProbe` - object, default: `{}`  
+
+  [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) options
+  Example:
+  ```yaml
+   initialDelaySeconds: 20
+   periodSeconds: 10
+   timeoutSeconds: 5
+   failureThreshold: 6
+   successThreshold: 1
+  ```
+* `coordinator.readinessProbe` - object, default: `{}`  
+
+  [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  Example:
+  ```yaml
+   initialDelaySeconds: 20
+   periodSeconds: 10
+   timeoutSeconds: 5
+   failureThreshold: 6
+   successThreshold: 1
+  ```
+* `coordinator.lifecycle` - object, default: `{}`  
+
+  Coordinator container [lifecycle events](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/)
+  Example:
+  ```yaml
+   preStop:
+     exec:
+       command: ["/bin/sh", "-c", "sleep 120"]
+  ```
+* `coordinator.terminationGracePeriodSeconds` - int, default: `30`
+* `coordinator.nodeSelector` - object, default: `{}`
+* `coordinator.tolerations` - list, default: `[]`
+* `coordinator.affinity` - object, default: `{}`
+* `coordinator.additionalConfigFiles` - object, default: `{}`
+* `coordinator.additionalVolumes` - list, default: `[]`  
+
+  One or more additional volumes to add to the coordinator.
+  Example:
+  ```yaml
+   - name: extras
+     emptyDir: {}
+  ```
+* `coordinator.additionalVolumeMounts` - list, default: `[]`  
+
+  One or more additional volume mounts to add to the coordinator.
+  Example:
+   - name: extras
+     mountPath: /usr/share/extras
+     readOnly: true
+* `coordinator.annotations` - object, default: `{}`
+* `coordinator.labels` - object, default: `{}`
+* `coordinator.secretMounts` - list, default: `[]`  
+
+  Allows mounting additional Trino configuration files from Kubernetes secrets on the coordinator node.
+  Example:
+   - name: sample-secret
+     secretName: sample-secret
+     path: /secrets/sample.json
+* `worker.jvm.maxHeapSize` - string, default: `"8G"`
+* `worker.jvm.gcMethod.type` - string, default: `"UseG1GC"`
+* `worker.jvm.gcMethod.g1.heapRegionSize` - string, default: `"32M"`
+* `worker.config.memory.heapHeadroomPerNode` - string, default: `""`
+* `worker.config.query.maxMemoryPerNode` - string, default: `"1GB"`
+* `worker.additionalJVMConfig` - list, default: `[]`
+* `worker.additionalExposedPorts` - object, default: `{}`
+* `worker.resources` - object, default: `{}`  
+
+  It is recommended not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. If you do want to specify resources, use the following example, and adjust it as necessary.
+  Example:
+  ```yaml
+   limits:
+     cpu: 100m
+     memory: 128Mi
+   requests:
+     cpu: 100m
+     memory: 128Mi
+  ```
+* `worker.livenessProbe` - object, default: `{}`  
+
+  [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  Example:
+  ```yaml
+   initialDelaySeconds: 20
+   periodSeconds: 10
+   timeoutSeconds: 5
+   failureThreshold: 6
+   successThreshold: 1
+  ```
+* `worker.readinessProbe` - object, default: `{}`  
+
+  [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  Example:
+  ```yaml
+   initialDelaySeconds: 20
+   periodSeconds: 10
+   timeoutSeconds: 5
+   failureThreshold: 6
+   successThreshold: 1
+  ```
+* `worker.lifecycle` - object, default: `{}`  
+
+  To enable [graceful shutdown](https://trino.io/docs/current/admin/graceful-shutdown.html), define a lifecycle preStop like bellow, Set the `terminationGracePeriodSeconds` to a value greater than or equal to the configured `shutdown.grace-period`. Configure `shutdown.grace-period` in `additionalConfigProperties` as `shutdown.grace-period=2m` (default is 2 minutes). Also configure `accessControl` because the `default` system access control does not allow graceful shutdowns.
+  Example:
+  ```yaml
+   preStop:
+     exec:
+       command: ["/bin/sh", "-c", "curl -v -X PUT -d '\"SHUTTING_DOWN\"' -H \"Content-type: application/json\" http://localhost:8081/v1/info/state"]
+  ```
+* `worker.terminationGracePeriodSeconds` - int, default: `30`
+* `worker.nodeSelector` - object, default: `{}`
+* `worker.tolerations` - list, default: `[]`
+* `worker.affinity` - object, default: `{}`
+* `worker.additionalConfigFiles` - object, default: `{}`
+* `worker.additionalVolumes` - list, default: `[]`  
+
+  One or more additional volume mounts to add to all workers.
+  Example:
+  ```yaml
+   - name: extras
+     emptyDir: {}
+  ```
+* `worker.additionalVolumeMounts` - list, default: `[]`  
+
+  One or more additional volume mounts to add to all workers.
+  Example:
+  ```yaml
+   - name: extras
+     mountPath: /usr/share/extras
+     readOnly: true
+  ```
+* `worker.annotations` - object, default: `{}`
+* `worker.labels` - object, default: `{}`
+* `worker.secretMounts` - list, default: `[]`  
+
+  Allows mounting additional Trino configuration files from Kubernetes secrets on all worker nodes.
+  Example:
+  ```yaml
+   - name: sample-secret
+     secretName: sample-secret
+     path: /secrets/sample.json
+  ```
+* `kafka.mountPath` - string, default: `"/etc/trino/schemas"`
+* `kafka.tableDescriptions` - object, default: `{}`  
+
+  Custom kafka table descriptions that will be mounted in mountPath.
+  Example:
+  ```yaml
+   testschema.json: |-
+     {
+       "tableName": "testtable",
+       "schemaName": "testschema",
+       "topicName": "testtopic",
+       "key": {
+         "dataFormat": "json",
+         "fields": [
+           {
+             "name": "_key",
+             "dataFormat": "VARCHAR",
+             "type": "VARCHAR",
+             "hidden": "false"
+           }
+         ]
+       },
+       "message": {
+         "dataFormat": "json",
+         "fields": [
+           {
+             "name": "id",
+             "mapping": "id",
+             "type": "BIGINT"
+           },
+           {
+             "name": "test_field",
+             "mapping": "test_field",
+             "type": "VARCHAR"
+           }
+         ]
+       }
+     }
+  ```
+* `commonLabels` - object, default: `{}`  
+
+  Labels that get applied to every resource's metadata
+* `ingress.enabled` - bool, default: `false`
+* `ingress.className` - string, default: `""`
+* `ingress.annotations` - object, default: `{}`
+* `ingress.hosts` - list, default: `[]`  
+
+  [Ingress rules](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules).
+  Example:
+  ```yaml
+   - host: trino.example.com
+     paths:
+       - path: /
+         pathType: ImplementationSpecific
+  ```
+* `ingress.tls` - list, default: `[]`
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -1,119 +1,120 @@
+# trino
 
-Trino
-===========
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 446](https://img.shields.io/badge/AppVersion-446-informational?style=flat-square)
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe
 
+**Homepage:** <https://trino.io/>
 
-## Configuration
+## Source Code
 
-The following table lists the configurable parameters of the Trino chart and their default values.
+* <https://github.com/trinodb/charts>
+* <https://github.com/trinodb/trino/tree/master/core/docker>
 
-| Parameter                | Description             | Default        |
-| ------------------------ | ----------------------- | -------------- |
-| `image.registry` | Image registry, defaults to empty, which results in DockerHub usage | `""` |
-| `image.repository` | Repository location of the Trino image, typically `organization/imagename` | `"trinodb/trino"` |
-| `image.tag` | Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml | `""` |
-| `image.digest` | Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`. | `""` |
-| `image.useRepositoryAsSoleImageReference` | When true, only the content in `repository` is used as image reference | `false` |
-| `image.pullPolicy` |  | `"IfNotPresent"` |
-| `imagePullSecrets` |  | `[{"name": "registry-credentials"}]` |
-| `server.workers` |  | `2` |
-| `server.node.environment` |  | `"production"` |
-| `server.node.dataDir` |  | `"/data/trino"` |
-| `server.node.pluginDir` |  | `"/usr/lib/trino/plugin"` |
-| `server.log.trino.level` |  | `"INFO"` |
-| `server.config.path` |  | `"/etc/trino"` |
-| `server.config.http.port` |  | `8080` |
-| `server.config.https.enabled` |  | `false` |
-| `server.config.https.port` |  | `8443` |
-| `server.config.https.keystore.path` |  | `""` |
-| `server.config.authenticationType` |  | `""` |
-| `server.config.query.maxMemory` |  | `"4GB"` |
-| `server.exchangeManager.name` |  | `"filesystem"` |
-| `server.exchangeManager.baseDir` |  | `"/tmp/trino-local-file-system-exchange-manager"` |
-| `server.workerExtraConfig` |  | `""` |
-| `server.coordinatorExtraConfig` |  | `""` |
-| `server.autoscaling.enabled` |  | `false` |
-| `server.autoscaling.maxReplicas` |  | `5` |
-| `server.autoscaling.targetCPUUtilizationPercentage` |  | `50` |
-| `server.autoscaling.behavior` |  | `{}` |
-| `accessControl` |  | `{}` |
-| `resourceGroups` |  | `{}` |
-| `additionalNodeProperties` |  | `{}` |
-| `additionalConfigProperties` |  | `{}` |
-| `additionalLogProperties` |  | `{}` |
-| `additionalExchangeManagerProperties` |  | `{}` |
-| `eventListenerProperties` |  | `{}` |
-| `additionalCatalogs` |  | `{}` |
-| `env` |  | `[]` |
-| `envFrom` |  | `[]` |
-| `initContainers` |  | `{}` |
-| `sidecarContainers` |  | `{}` |
-| `securityContext.runAsUser` |  | `1000` |
-| `securityContext.runAsGroup` |  | `1000` |
-| `shareProcessNamespace.coordinator` |  | `false` |
-| `shareProcessNamespace.worker` |  | `false` |
-| `service.type` |  | `"ClusterIP"` |
-| `service.port` |  | `8080` |
-| `auth` |  | `{}` |
-| `serviceAccount.create` |  | `false` |
-| `serviceAccount.name` |  | `""` |
-| `serviceAccount.annotations` |  | `{}` |
-| `secretMounts` |  | `[]` |
-| `coordinator.jvm.maxHeapSize` |  | `"8G"` |
-| `coordinator.jvm.gcMethod.type` |  | `"UseG1GC"` |
-| `coordinator.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
-| `coordinator.config.memory.heapHeadroomPerNode` |  | `""` |
-| `coordinator.config.query.maxMemoryPerNode` |  | `"1GB"` |
-| `coordinator.additionalJVMConfig` |  | `[]` |
-| `coordinator.additionalExposedPorts` |  | `{}` |
-| `coordinator.resources` |  | `{}` |
-| `coordinator.livenessProbe` |  | `{}` |
-| `coordinator.readinessProbe` |  | `{}` |
-| `coordinator.lifecycle` |  | `{}` |
-| `coordinator.terminationGracePeriodSeconds` |  | `30` |
-| `coordinator.nodeSelector` |  | `{}` |
-| `coordinator.tolerations` |  | `[]` |
-| `coordinator.affinity` |  | `{}` |
-| `coordinator.additionalConfigFiles` |  | `{}` |
-| `coordinator.additionalVolumes` | One or more additional volumes to add to the coordinator. | `[]` |
-| `coordinator.additionalVolumeMounts` | One or more additional volume mounts to add to the coordinator. | `[]` |
-| `coordinator.annotations` |  | `{}` |
-| `coordinator.labels` |  | `{}` |
-| `coordinator.secretMounts` |  | `[]` |
-| `worker.jvm.maxHeapSize` |  | `"8G"` |
-| `worker.jvm.gcMethod.type` |  | `"UseG1GC"` |
-| `worker.jvm.gcMethod.g1.heapRegionSize` |  | `"32M"` |
-| `worker.config.memory.heapHeadroomPerNode` |  | `""` |
-| `worker.config.query.maxMemoryPerNode` |  | `"1GB"` |
-| `worker.additionalJVMConfig` |  | `[]` |
-| `worker.additionalExposedPorts` |  | `{}` |
-| `worker.resources` |  | `{}` |
-| `worker.livenessProbe` |  | `{}` |
-| `worker.readinessProbe` |  | `{}` |
-| `worker.lifecycle` |  | `{}` |
-| `worker.terminationGracePeriodSeconds` |  | `30` |
-| `worker.nodeSelector` |  | `{}` |
-| `worker.tolerations` |  | `[]` |
-| `worker.affinity` |  | `{}` |
-| `worker.additionalConfigFiles` |  | `{}` |
-| `worker.additionalVolumes` | One or more additional volume mounts to add to all workers. | `[]` |
-| `worker.additionalVolumeMounts` | One or more additional volume mounts to add to all workers. | `[]` |
-| `worker.annotations` |  | `{}` |
-| `worker.labels` |  | `{}` |
-| `worker.secretMounts` |  | `[]` |
-| `kafka.mountPath` |  | `"/etc/trino/schemas"` |
-| `kafka.tableDescriptions` |  | `{}` |
-| `commonLabels` | Labels that get applied to every resource's metadata | `{}` |
-| `ingress.enabled` |  | `false` |
-| `ingress.className` |  | `""` |
-| `ingress.annotations` |  | `{}` |
-| `ingress.hosts` |  | `[]` |
-| `ingress.tls` |  | `[]` |
+## Values
 
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| accessControl | object | `{}` |  |
+| additionalCatalogs | object | `{}` |  |
+| additionalConfigProperties | object | `{}` |  |
+| additionalExchangeManagerProperties | object | `{}` |  |
+| additionalLogProperties | object | `{}` |  |
+| additionalNodeProperties | object | `{}` |  |
+| auth | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| coordinator.additionalConfigFiles | object | `{}` |  |
+| coordinator.additionalExposedPorts | object | `{}` |  |
+| coordinator.additionalJVMConfig | list | `[]` |  |
+| coordinator.additionalVolumeMounts | list | `[]` |  |
+| coordinator.additionalVolumes | list | `[]` |  |
+| coordinator.affinity | object | `{}` |  |
+| coordinator.annotations | object | `{}` |  |
+| coordinator.config.memory.heapHeadroomPerNode | string | `""` |  |
+| coordinator.config.query.maxMemoryPerNode | string | `"1GB"` |  |
+| coordinator.jvm.gcMethod.g1.heapRegionSize | string | `"32M"` |  |
+| coordinator.jvm.gcMethod.type | string | `"UseG1GC"` |  |
+| coordinator.jvm.maxHeapSize | string | `"8G"` |  |
+| coordinator.labels | object | `{}` |  |
+| coordinator.lifecycle | object | `{}` |  |
+| coordinator.livenessProbe | object | `{}` |  |
+| coordinator.nodeSelector | object | `{}` |  |
+| coordinator.readinessProbe | object | `{}` |  |
+| coordinator.resources | object | `{}` |  |
+| coordinator.secretMounts | list | `[]` |  |
+| coordinator.terminationGracePeriodSeconds | int | `30` |  |
+| coordinator.tolerations | list | `[]` |  |
+| env | list | `[]` |  |
+| envFrom | list | `[]` |  |
+| eventListenerProperties | object | `{}` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `""` |  |
+| image.repository | string | `"trinodb/trino"` |  |
+| image.tag | string | `""` |  |
+| image.useRepositoryAsSoleImageReference | bool | `false` |  |
+| imagePullSecrets[0].name | string | `"registry-credentials"` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
+| initContainers | object | `{}` |  |
+| kafka.mountPath | string | `"/etc/trino/schemas"` |  |
+| kafka.tableDescriptions | object | `{}` |  |
+| resourceGroups | object | `{}` |  |
+| secretMounts | list | `[]` |  |
+| securityContext.runAsGroup | int | `1000` |  |
+| securityContext.runAsUser | int | `1000` |  |
+| server.autoscaling.behavior | object | `{}` |  |
+| server.autoscaling.enabled | bool | `false` |  |
+| server.autoscaling.maxReplicas | int | `5` |  |
+| server.autoscaling.targetCPUUtilizationPercentage | int | `50` |  |
+| server.config.authenticationType | string | `""` |  |
+| server.config.http.port | int | `8080` |  |
+| server.config.https.enabled | bool | `false` |  |
+| server.config.https.keystore.path | string | `""` |  |
+| server.config.https.port | int | `8443` |  |
+| server.config.path | string | `"/etc/trino"` |  |
+| server.config.query.maxMemory | string | `"4GB"` |  |
+| server.coordinatorExtraConfig | string | `""` |  |
+| server.exchangeManager.baseDir | string | `"/tmp/trino-local-file-system-exchange-manager"` |  |
+| server.exchangeManager.name | string | `"filesystem"` |  |
+| server.log.trino.level | string | `"INFO"` |  |
+| server.node.dataDir | string | `"/data/trino"` |  |
+| server.node.environment | string | `"production"` |  |
+| server.node.pluginDir | string | `"/usr/lib/trino/plugin"` |  |
+| server.workerExtraConfig | string | `""` |  |
+| server.workers | int | `2` |  |
+| service.port | int | `8080` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| shareProcessNamespace.coordinator | bool | `false` |  |
+| shareProcessNamespace.worker | bool | `false` |  |
+| sidecarContainers | object | `{}` |  |
+| worker.additionalConfigFiles | object | `{}` |  |
+| worker.additionalExposedPorts | object | `{}` |  |
+| worker.additionalJVMConfig | list | `[]` |  |
+| worker.additionalVolumeMounts | list | `[]` |  |
+| worker.additionalVolumes | list | `[]` |  |
+| worker.affinity | object | `{}` |  |
+| worker.annotations | object | `{}` |  |
+| worker.config.memory.heapHeadroomPerNode | string | `""` |  |
+| worker.config.query.maxMemoryPerNode | string | `"1GB"` |  |
+| worker.jvm.gcMethod.g1.heapRegionSize | string | `"32M"` |  |
+| worker.jvm.gcMethod.type | string | `"UseG1GC"` |  |
+| worker.jvm.maxHeapSize | string | `"8G"` |  |
+| worker.labels | object | `{}` |  |
+| worker.lifecycle | object | `{}` |  |
+| worker.livenessProbe | object | `{}` |  |
+| worker.nodeSelector | object | `{}` |  |
+| worker.readinessProbe | object | `{}` |  |
+| worker.resources | object | `{}` |  |
+| worker.secretMounts | list | `[]` |  |
+| worker.terminationGracePeriodSeconds | int | `30` |  |
+| worker.tolerations | list | `[]` |  |
 
-
----
-_Documentation generated by [Frigate](https://frigate.readthedocs.io)._
-
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)

--- a/charts/trino/README.md.gotmpl
+++ b/charts/trino/README.md.gotmpl
@@ -11,6 +11,15 @@
 
 {{ template "chart.requirementsSection" . }}
 
-{{ template "chart.valuesSection" . }}
+{{ template "chart.valuesHeader" . }}
+
+{{- range .Values }}
+* `{{ .Key }}` - {{ .Type }}, default: {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }}{{ if or .Description .AutoDescription }}   {{ end }}
+{{- if .Description }}
+{{ .Description | nindent 2 }}
+{{- else if .AutoDescription }}
+{{ .AutoDescription | nindent 2 }}
+{{- end }}
+{{- end }}
 
 {{ template "helm-docs.versionFooter" . }}

--- a/charts/trino/README.md.gotmpl
+++ b/charts/trino/README.md.gotmpl
@@ -1,0 +1,16 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/trino/templates/autoscaler.yaml
+++ b/charts/trino/templates/autoscaler.yaml
@@ -23,7 +23,7 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
   {{ if .Values.server.autoscaling.behavior -}}
-  behavior: 
+  behavior:
     {{- toYaml .Values.server.autoscaling.behavior | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/trino/templates/configmap-catalog.yaml
+++ b/charts/trino/templates/configmap-catalog.yaml
@@ -23,5 +23,3 @@ data:
   {{ $catalogName }}.properties: |
     {{- $catalogProperties | nindent 4 }}
 {{- end }}
-
-

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -90,7 +90,7 @@ data:
     exchange-manager.name={{ .Values.server.exchangeManager.name }}
   {{ if eq .Values.server.exchangeManager.name "filesystem" }}
     exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
-  {{- end }}  
+  {{- end }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
     {{ $configValue }}
   {{- end }}
@@ -154,7 +154,7 @@ metadata:
     namespace: {{ .Release.Namespace }}
     app.kubernetes.io/component: coordinator
 data:
-  resource-groups.json: |- 
+  resource-groups.json: |-
     {{- .Values.resourceGroups.resourceGroupsConfig | nindent 4 }}
 {{- end }}
 ---

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -63,7 +63,7 @@ data:
     exchange-manager.name={{ .Values.server.exchangeManager.name }}
   {{ if eq .Values.server.exchangeManager.name "filesystem" }}
     exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
-  {{- end }}  
+  {{- end }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
     {{ $configValue }}
   {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -76,7 +76,7 @@ spec:
               {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret }}
               - key: password.db
                 path: password.db
-              {{- end }} 
+              {{- end }}
               {{- if .Values.auth.groups }}
               - key: group.db
                 path: group.db

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -3,11 +3,16 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: ""   # Image registry, defaults to empty, which results in DockerHub usage
-  repository: trinodb/trino    # Repository location of the Trino image, typically `organization/imagename`
-  tag: ""   # Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
-  digest: ""   # Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
-  useRepositoryAsSoleImageReference: false  # When true, only the content in `repository` is used as image reference
+  # Image registry, defaults to empty, which results in DockerHub usage
+  registry: ""
+  # Repository location of the Trino image, typically `organization/imagename`
+  repository: trinodb/trino
+  # Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
+  tag: ""
+  # Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
+  digest: ""
+  # When true, only the content in `repository` is used as image reference
+  useRepositoryAsSoleImageReference: false
   pullPolicy: IfNotPresent
 
 imagePullSecrets:
@@ -64,114 +69,114 @@ server:
     #    selectPolicy: Max
 
 accessControl: {}
-  # type: configmap
-  # refreshPeriod: 60s
-  # # Rules file is mounted to /etc/trino/access-control
-  # configFile: "rules.json"
-  # rules:
-  #   rules.json: |-
-  #     {
-  #       "catalogs": [
-  #         {
-  #           "user": "admin",
-  #           "catalog": "(mysql|system)",
-  #           "allow": "all"
-  #         },
-  #         {
-  #           "group": "finance|human_resources",
-  #           "catalog": "postgres",
-  #           "allow": true
-  #         },
-  #         {
-  #           "catalog": "hive",
-  #           "allow": "all"
-  #         },
-  #         {
-  #           "user": "alice",
-  #           "catalog": "postgresql",
-  #           "allow": "read-only"
-  #         },
-  #         {
-  #           "catalog": "system",
-  #           "allow": "none"
-  #         }
-  #       ],
-  #       "schemas": [
-  #         {
-  #           "user": "admin",
-  #           "schema": ".*",
-  #           "owner": true
-  #         },
-  #         {
-  #           "user": "guest",
-  #           "owner": false
-  #         },
-  #         {
-  #           "catalog": "default",
-  #           "schema": "default",
-  #           "owner": true
-  #         }
-  #       ]
-  #     }
+#  type: configmap
+#  refreshPeriod: 60s
+#  # Rules file is mounted to /etc/trino/access-control
+#  configFile: "rules.json"
+#  rules:
+#    rules.json: |-
+#      {
+#        "catalogs": [
+#          {
+#            "user": "admin",
+#            "catalog": "(mysql|system)",
+#            "allow": "all"
+#          },
+#          {
+#            "group": "finance|human_resources",
+#            "catalog": "postgres",
+#            "allow": true
+#          },
+#          {
+#            "catalog": "hive",
+#            "allow": "all"
+#          },
+#          {
+#            "user": "alice",
+#            "catalog": "postgresql",
+#            "allow": "read-only"
+#          },
+#          {
+#            "catalog": "system",
+#            "allow": "none"
+#          }
+#        ],
+#        "schemas": [
+#          {
+#            "user": "admin",
+#            "schema": ".*",
+#            "owner": true
+#          },
+#          {
+#            "user": "guest",
+#            "owner": false
+#          },
+#          {
+#            "catalog": "default",
+#            "schema": "default",
+#            "owner": true
+#          }
+#        ]
+#      }
 
 resourceGroups: {}
-  # # Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
-  # resourceGroupsConfig: |-
-  #     {
-  #       "rootGroups": [
-  #         {
-  #           "name": "global",
-  #           "softMemoryLimit": "80%",
-  #           "hardConcurrencyLimit": 100,
-  #           "maxQueued": 100,
-  #           "schedulingPolicy": "fair",
-  #           "jmxExport": true,
-  #           "subGroups": [
-  #             {
-  #               "name": "admin",
-  #               "softMemoryLimit": "30%",
-  #               "hardConcurrencyLimit": 20,
-  #               "maxQueued": 10
-  #             },
-  #             {
-  #               "name": "finance_human_resources",
-  #               "softMemoryLimit": "20%",
-  #               "hardConcurrencyLimit": 15,
-  #               "maxQueued": 10
-  #             },
-  #             {
-  #               "name": "general",
-  #               "softMemoryLimit": "30%",
-  #               "hardConcurrencyLimit": 20,
-  #               "maxQueued": 10
-  #             },
-  #             {
-  #               "name": "readonly",
-  #               "softMemoryLimit": "10%",
-  #               "hardConcurrencyLimit": 5,
-  #               "maxQueued": 5
-  #             }
-  #           ]
-  #         }
-  #       ],
-  #       "selectors": [
-  #         {
-  #           "user": "admin",
-  #           "group": "global.admin"
-  #         },
-  #         {
-  #           "group": "finance|human_resources",
-  #           "group": "global.finance_human_resources"
-  #         },
-  #         {
-  #           "user": "alice",
-  #           "group": "global.readonly"
-  #         },
-  #         {
-  #           "group": "global.general"
-  #         }
-  #       ]
-  #     }
+#  # Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
+#  resourceGroupsConfig: |-
+#      {
+#        "rootGroups": [
+#          {
+#            "name": "global",
+#            "softMemoryLimit": "80%",
+#            "hardConcurrencyLimit": 100,
+#            "maxQueued": 100,
+#            "schedulingPolicy": "fair",
+#            "jmxExport": true,
+#            "subGroups": [
+#              {
+#                "name": "admin",
+#                "softMemoryLimit": "30%",
+#                "hardConcurrencyLimit": 20,
+#                "maxQueued": 10
+#              },
+#              {
+#                "name": "finance_human_resources",
+#                "softMemoryLimit": "20%",
+#                "hardConcurrencyLimit": 15,
+#                "maxQueued": 10
+#              },
+#              {
+#                "name": "general",
+#                "softMemoryLimit": "30%",
+#                "hardConcurrencyLimit": 20,
+#                "maxQueued": 10
+#              },
+#              {
+#                "name": "readonly",
+#                "softMemoryLimit": "10%",
+#                "hardConcurrencyLimit": 5,
+#                "maxQueued": 5
+#              }
+#            ]
+#          }
+#        ],
+#        "selectors": [
+#          {
+#            "user": "admin",
+#            "group": "global.admin"
+#          },
+#          {
+#            "group": "finance|human_resources",
+#            "group": "global.finance_human_resources"
+#          },
+#          {
+#            "user": "alice",
+#            "group": "global.readonly"
+#          },
+#          {
+#            "group": "global.general"
+#          }
+#        ]
+#      }
 
 
 additionalNodeProperties: {}
@@ -193,27 +198,27 @@ env: []
 envFrom: []
 
 initContainers: {}
-  # coordinator:
-  #   - name: init-coordinator
-  #     image: busybox:1.28
-  #     imagePullPolicy: IfNotPresent
-  #     command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
-  # worker:
-  #   - name: init-worker
-  #     image: busybox:1.28
-  #     command: ['sh', '-c', 'echo The worker is running! && sleep 3600']
+#  coordinator:
+#    - name: init-coordinator
+#      image: busybox:1.28
+#      imagePullPolicy: IfNotPresent
+#      command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+#  worker:
+#    - name: init-worker
+#      image: busybox:1.28
+#      command: ['sh', '-c', 'echo The worker is running! && sleep 3600']
 
 sidecarContainers: {}
-#   coordinator:
-#     - name: side-coordinator
-#       image: busybox:1.28
-#       imagePullPolicy: IfNotPresent
-#       command: ['sleep', '1']
-#   worker:
-#     - name: side-worker
-#       image: busybox:1.28
-#       imagePullPolicy: IfNotPresent
-#       command: ['sleep', '1']
+#  coordinator:
+#    - name: side-coordinator
+#      image: busybox:1.28
+#      imagePullPolicy: IfNotPresent
+#      command: ['sleep', '1']
+#  worker:
+#    - name: side-worker
+#      image: busybox:1.28
+#      imagePullPolicy: IfNotPresent
+#      command: ['sleep', '1']
 
 securityContext:
   runAsUser: 1000
@@ -228,15 +233,15 @@ service:
   port: 8080
 
 auth: {}
-  # Set username and password
-  # https://trino.io/docs/current/security/password-file.html#file-format
-  # passwordAuth: "username:encrypted-password-with-htpasswd"
-  # or set the name of a secret containing this file in the password.db key
-  # passwordAuthSecret: "trino-password-authentication"
-  # Set users' groups
-  # https://trino.io/docs/current/security/group-file.html#file-format
-  # refreshPeriod: 5s
-  # groups: "group_name:user_1,user_2,user_3"
+# Set username and password
+# https://trino.io/docs/current/security/password-file.html#file-format
+#  passwordAuth: "username:encrypted-password-with-htpasswd"
+# or set the name of a secret containing this file in the password.db key
+#  passwordAuthSecret: "trino-password-authentication"
+# Set users' groups
+# https://trino.io/docs/current/security/group-file.html#file-format
+#  refreshPeriod: 5s
+#  groups: "group_name:user_1,user_2,user_3"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -248,9 +253,9 @@ serviceAccount:
   annotations: {}
 
 secretMounts: []
-  # - name: sample-secret
-  #   secretName: sample-secret
-  #   path: /secrets/sample.json
+#  - name: sample-secret
+#    secretName: sample-secret
+#    path: /secrets/sample.json
 
 coordinator:
   jvm:
@@ -271,34 +276,34 @@ coordinator:
   additionalExposedPorts: {}
 
   resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
 
   livenessProbe: {}
-    # initialDelaySeconds: 20
-    # periodSeconds: 10
-    # timeoutSeconds: 5
-    # failureThreshold: 6
-    # successThreshold: 1
+  #  initialDelaySeconds: 20
+  #  periodSeconds: 10
+  #  timeoutSeconds: 5
+  #  failureThreshold: 6
+  #  successThreshold: 1
   readinessProbe: {}
-    # initialDelaySeconds: 20
-    # periodSeconds: 10
-    # timeoutSeconds: 5
-    # failureThreshold: 6
-    # successThreshold: 1
+  #  initialDelaySeconds: 20
+  #  periodSeconds: 10
+  #  timeoutSeconds: 5
+  #  failureThreshold: 6
+  #  successThreshold: 1
 
   lifecycle: {}
-    # preStop:
-    #   exec:
-    #     command: ["/bin/sh", "-c", "sleep 120"]
+  #  preStop:
+  #    exec:
+  #      command: ["/bin/sh", "-c", "sleep 120"]
 
   terminationGracePeriodSeconds: 30
 
@@ -310,23 +315,25 @@ coordinator:
 
   additionalConfigFiles: {}
 
-  additionalVolumes: []  # One or more additional volumes to add to the coordinator.
-    # - name: extras
-    #   emptyDir: {}
+  additionalVolumes: []
+  # One or more additional volumes to add to the coordinator.
+  #  - name: extras
+  #    emptyDir: {}
 
-  additionalVolumeMounts: []  # One or more additional volume mounts to add to the coordinator.
-    # - name: extras
-    #   mountPath: /usr/share/extras
-    #   readOnly: true
+  additionalVolumeMounts: []
+  # One or more additional volume mounts to add to the coordinator.
+  #  - name: extras
+  #    mountPath: /usr/share/extras
+  #    readOnly: true
 
   annotations: {}
 
   labels: {}
 
   secretMounts: []
-    # - name: sample-secret
-    #   secretName: sample-secret
-    #   path: /secrets/sample.json
+  #  - name: sample-secret
+  #    secretName: sample-secret
+  #    path: /secrets/sample.json
 
 worker:
   jvm:
@@ -347,39 +354,39 @@ worker:
   additionalExposedPorts: {}
 
   resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
 
   livenessProbe: {}
-    # initialDelaySeconds: 20
-    # periodSeconds: 10
-    # timeoutSeconds: 5
-    # failureThreshold: 6
-    # successThreshold: 1
+  #  initialDelaySeconds: 20
+  #  periodSeconds: 10
+  #  timeoutSeconds: 5
+  #  failureThreshold: 6
+  #  successThreshold: 1
   readinessProbe: {}
-    # initialDelaySeconds: 20
-    # periodSeconds: 10
-    # timeoutSeconds: 5
-    # failureThreshold: 6
-    # successThreshold: 1
+  #  initialDelaySeconds: 20
+  #  periodSeconds: 10
+  #  timeoutSeconds: 5
+  #  failureThreshold: 6
+  #  successThreshold: 1
 
   lifecycle: {}
-    # To enable Graceful shutdown, Define a lifecycle preStop like bellow,
-    # Set the `terminationGracePeriodSeconds` to a value greater than or equal to the configured `shutdown.grace-period`.
-    # Configure `shutdown.grace-period` in `additionalConfigProperties` as `shutdown.grace-period=2m` (default is 2 minutes).
-    # Allow the operation on `accessControl` because isn't allow by default.
-    # Check the documentaion on https://trino.io/docs/current/admin/graceful-shutdown.html
-    # preStop:
-    #   exec:
-    #     command: ["/bin/sh", "-c", "curl -v -X PUT -d '\"SHUTTING_DOWN\"' -H \"Content-type: application/json\" http://localhost:8081/v1/info/state"]
+  # To enable Graceful shutdown, Define a lifecycle preStop like bellow,
+  # Set the `terminationGracePeriodSeconds` to a value greater than or equal to the configured `shutdown.grace-period`.
+  # Configure `shutdown.grace-period` in `additionalConfigProperties` as `shutdown.grace-period=2m` (default is 2 minutes).
+  # Allow the operation on `accessControl` because isn't allow by default.
+  # Check the documentaion on https://trino.io/docs/current/admin/graceful-shutdown.html
+  #  preStop:
+  #    exec:
+  #      command: ["/bin/sh", "-c", "curl -v -X PUT -d '\"SHUTTING_DOWN\"' -H \"Content-type: application/json\" http://localhost:8081/v1/info/state"]
 
   terminationGracePeriodSeconds: 30
 
@@ -391,61 +398,65 @@ worker:
 
   additionalConfigFiles: {}
 
-  additionalVolumes: []  # One or more additional volume mounts to add to all workers.
-    # - name: extras
-    #   emptyDir: {}
+  additionalVolumes: []
+  # One or more additional volume mounts to add to all workers.
+  #  - name: extras
+  #    emptyDir: {}
 
-  additionalVolumeMounts: []  # One or more additional volume mounts to add to all workers.
-    # - name: extras
-    #   mountPath: /usr/share/extras
-    #   readOnly: true
+  additionalVolumeMounts: []
+  # One or more additional volume mounts to add to all workers.
+  #  - name: extras
+  #    mountPath: /usr/share/extras
+  #    readOnly: true
 
   annotations: {}
 
   labels: {}
 
   secretMounts: []
-    # - name: sample-secret
-    #   secretName: sample-secret
-    #   path: /secrets/sample.json
+  #  - name: sample-secret
+  #    secretName: sample-secret
+  #    path: /secrets/sample.json
 
 kafka:
   mountPath: "/etc/trino/schemas"
   tableDescriptions: {}
-    # Custom kafka table descriptions that will be mounted in mountPath
-    # testschema.json: |-
-    #   {
-    #     "tableName": "testtable",
-    #     "schemaName": "testschema",
-    #     "topicName": "testtopic",
-    #     "key": {
-    #       "dataFormat": "json",
-    #       "fields": [
-    #         {
-    #           "name": "_key",
-    #           "dataFormat": "VARCHAR",
-    #           "type": "VARCHAR",
-    #           "hidden": "false"
-    #         }
-    #       ]
-    #     },
-    #     "message": {
-    #       "dataFormat": "json",
-    #       "fields": [
-    #         {
-    #           "name": "id",
-    #           "mapping": "id",
-    #           "type": "BIGINT"
-    #         },
-    #         {
-    #           "name": "test_field",
-    #           "mapping": "test_field",
-    #           "type": "VARCHAR"
-    #         }
-    #       ]
-    #     }
-    #   }
-commonLabels: {}  # Labels that get applied to every resource's metadata
+  # Custom kafka table descriptions that will be mounted in mountPath
+  #  testschema.json: |-
+  #    {
+  #      "tableName": "testtable",
+  #      "schemaName": "testschema",
+  #      "topicName": "testtopic",
+  #      "key": {
+  #        "dataFormat": "json",
+  #        "fields": [
+  #          {
+  #            "name": "_key",
+  #            "dataFormat": "VARCHAR",
+  #            "type": "VARCHAR",
+  #            "hidden": "false"
+  #          }
+  #        ]
+  #      },
+  #      "message": {
+  #        "dataFormat": "json",
+  #        "fields": [
+  #          {
+  #            "name": "id",
+  #            "mapping": "id",
+  #            "type": "BIGINT"
+  #          },
+  #          {
+  #            "name": "test_field",
+  #            "mapping": "test_field",
+  #            "type": "VARCHAR"
+  #          }
+  #        ]
+  #      }
+  #    }
+
+# Labels that get applied to every resource's metadata
+commonLabels: {}
 ingress:
   enabled: false
   className: ""

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -3,15 +3,15 @@
 # Declare variables to be passed into your templates.
 
 image:
-  # Image registry, defaults to empty, which results in DockerHub usage
+  # -- Image registry, defaults to empty, which results in DockerHub usage
   registry: ""
-  # Repository location of the Trino image, typically `organization/imagename`
+  # -- Repository location of the Trino image, typically `organization/imagename`
   repository: trinodb/trino
-  # Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
+  # -- Image tag, defaults to the Trino release version specified as `appVersion` from Chart.yaml
   tag: ""
-  # Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
+  # -- Optional digest value of the image specified as `sha256:abcd...`. A specified value overrides `tag`.
   digest: ""
-  # When true, only the content in `repository` is used as image reference
+  # -- When true, only the content in `repository` is used as image reference
   useRepositoryAsSoleImageReference: false
   pullPolicy: IfNotPresent
 
@@ -36,8 +36,9 @@ server:
       port: 8443
       keystore:
         path: ""
-    # Trino supports multiple authentication types: PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS
-    # For more info: https://trino.io/docs/current/security/authentication-types.html
+    # -- Trino supports multiple [authentication
+    # types](https://trino.io/docs/current/security/authentication-types.html):
+    # PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS.
     authenticationType: ""
     query:
       maxMemory: "4GB"
@@ -51,6 +52,10 @@ server:
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
     behavior: {}
+    # server.autoscaling.behavior -- Configuration for scaling up and down.
+    # @raw
+    # Example:
+    # ```yaml
     #  scaleDown:
     #    stabilizationWindowSeconds: 300
     #    policies:
@@ -67,8 +72,15 @@ server:
     #      value: 4
     #      periodSeconds: 15
     #    selectPolicy: Max
+    # ```
 
 accessControl: {}
+# accessControl -- [System access
+# control](https://trino.io/docs/current/security/built-in-system-access-control.html)
+# configuration.
+# @raw
+# Example:
+# ```yaml
 #  type: configmap
 #  refreshPeriod: 60s
 #  # Rules file is mounted to /etc/trino/access-control
@@ -118,9 +130,13 @@ accessControl: {}
 #          }
 #        ]
 #      }
+# ```
 
 resourceGroups: {}
-#  # Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
+# resourceGroups -- Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
+# @raw
+# Example:
+# ```yaml
 #  resourceGroupsConfig: |-
 #      {
 #        "rootGroups": [
@@ -177,6 +193,7 @@ resourceGroups: {}
 #          }
 #        ]
 #      }
+# ```
 
 
 additionalNodeProperties: {}
@@ -191,13 +208,31 @@ eventListenerProperties: {}
 
 additionalCatalogs: {}
 
-# Array of EnvVar (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core)
 env: []
+# env -- additional environment variables added to every pod, specified as a list with explicit values
+# @raw
+# Example:
+# ```yaml
+#  - name: NAME
+#    value: "value"
+# ```
 
-# Array of EnvFromSource (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envfromsource-v1-core)
 envFrom: []
+# envFrom -- additional environment variables added to every pod, specified as a list of either ConfigMap or Secret references
+# @raw
+# Example:
+# ```yaml
+#   - secretRef:
+#     name: extra-secret
+# ```
 
 initContainers: {}
+# initContainers -- Additional [containers that run to
+# completion](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
+# during pod initialization.
+# @raw
+# Example:
+# ```yaml
 #  coordinator:
 #    - name: init-coordinator
 #      image: busybox:1.28
@@ -207,8 +242,15 @@ initContainers: {}
 #    - name: init-worker
 #      image: busybox:1.28
 #      command: ['sh', '-c', 'echo The worker is running! && sleep 3600']
+# ```
 
 sidecarContainers: {}
+# sidecarContainers -- Additional [containers that starts
+# before](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)
+# the Trino container and continues to run.
+# @raw
+# Example:
+# ```yaml
 #  coordinator:
 #    - name: side-coordinator
 #      image: busybox:1.28
@@ -219,6 +261,7 @@ sidecarContainers: {}
 #      image: busybox:1.28
 #      imagePullPolicy: IfNotPresent
 #      command: ['sleep', '1']
+# ```
 
 securityContext:
   runAsUser: 1000
@@ -233,29 +276,41 @@ service:
   port: 8080
 
 auth: {}
-# Set username and password
-# https://trino.io/docs/current/security/password-file.html#file-format
+# auth -- Available authentication methods.
+# @raw
+# Use username and password provided as a [password file](https://trino.io/docs/current/security/password-file.html#file-format):
+# ```yaml
 #  passwordAuth: "username:encrypted-password-with-htpasswd"
-# or set the name of a secret containing this file in the password.db key
+# ```
+# Set the name of a secret containing this file in the password.db key
+# ```yaml
 #  passwordAuthSecret: "trino-password-authentication"
-# Set users' groups
-# https://trino.io/docs/current/security/group-file.html#file-format
+# ```
+# Additionally, set [users' groups](https://trino.io/docs/current/security/group-file.html#file-format):
+# ```yaml
 #  refreshPeriod: 5s
 #  groups: "group_name:user_1,user_2,user_3"
+# ```
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: false
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
 
 secretMounts: []
+# secretMounts -- Allows mounting additional Trino configuration files from
+# Kubernetes secrets on all nodes.
+# @raw
+# Example:
+# ```yaml
 #  - name: sample-secret
 #    secretName: sample-secret
 #    path: /secrets/sample.json
+# ```
 
 coordinator:
   jvm:
@@ -276,34 +331,58 @@ coordinator:
   additionalExposedPorts: {}
 
   resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # coordinator.resources -- It is recommended not to specify default resources
+  # and to leave this as a conscious choice for the user. This also increases
+  # chances charts run on environments with little resources, such as Minikube.
+  # If you do want to specify resources, use the following example, and adjust
+  # it as necessary.
+  # @raw
+  # Example:
+  # ```yaml
   #  limits:
   #    cpu: 100m
   #    memory: 128Mi
   #  requests:
   #    cpu: 100m
   #    memory: 128Mi
+  # ```
 
   livenessProbe: {}
+  # coordinator.livenessProbe -- [Liveness
+  # probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  # options
+  # @raw
+  # Example:
+  # ```yaml
   #  initialDelaySeconds: 20
   #  periodSeconds: 10
   #  timeoutSeconds: 5
   #  failureThreshold: 6
   #  successThreshold: 1
+  # ```
   readinessProbe: {}
+  # coordinator.readinessProbe -- [Readiness
+  # probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  # @raw
+  # Example:
+  # ```yaml
   #  initialDelaySeconds: 20
   #  periodSeconds: 10
   #  timeoutSeconds: 5
   #  failureThreshold: 6
   #  successThreshold: 1
+  # ```
 
   lifecycle: {}
+  # coordinator.lifecycle -- Coordinator container [lifecycle
+  # events](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/)
+  # @raw
+  # Example:
+  # ```yaml
   #  preStop:
   #    exec:
   #      command: ["/bin/sh", "-c", "sleep 120"]
+  # ```
 
   terminationGracePeriodSeconds: 30
 
@@ -316,12 +395,18 @@ coordinator:
   additionalConfigFiles: {}
 
   additionalVolumes: []
-  # One or more additional volumes to add to the coordinator.
+  # coordinator.additionalVolumes -- One or more additional volumes to add to the coordinator.
+  # @raw
+  # Example:
+  # ```yaml
   #  - name: extras
   #    emptyDir: {}
+  # ```
 
   additionalVolumeMounts: []
-  # One or more additional volume mounts to add to the coordinator.
+  # coordinator.additionalVolumeMounts -- One or more additional volume mounts to add to the coordinator.
+  # @raw
+  # Example:
   #  - name: extras
   #    mountPath: /usr/share/extras
   #    readOnly: true
@@ -331,6 +416,10 @@ coordinator:
   labels: {}
 
   secretMounts: []
+  # coordinator.secretMounts -- Allows mounting additional Trino configuration
+  # files from Kubernetes secrets on the coordinator node.
+  # @raw
+  # Example:
   #  - name: sample-secret
   #    secretName: sample-secret
   #    path: /secrets/sample.json
@@ -354,39 +443,63 @@ worker:
   additionalExposedPorts: {}
 
   resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # worker.resources -- It is recommended not to specify default resources and
+  # to leave this as a conscious choice for the user. This also increases
+  # chances charts run on environments with little resources, such as Minikube.
+  # If you do want to specify resources, use the following example, and adjust
+  # it as necessary.
+  # @raw
+  # Example:
+  # ```yaml
   #  limits:
   #    cpu: 100m
   #    memory: 128Mi
   #  requests:
   #    cpu: 100m
   #    memory: 128Mi
+  # ```
 
   livenessProbe: {}
+  # worker.livenessProbe -- [Liveness
+  # probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  # @raw
+  # Example:
+  # ```yaml
   #  initialDelaySeconds: 20
   #  periodSeconds: 10
   #  timeoutSeconds: 5
   #  failureThreshold: 6
   #  successThreshold: 1
+  # ```
   readinessProbe: {}
+  # worker.readinessProbe -- [Readiness
+  # probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  # @raw
+  # Example:
+  # ```yaml
   #  initialDelaySeconds: 20
   #  periodSeconds: 10
   #  timeoutSeconds: 5
   #  failureThreshold: 6
   #  successThreshold: 1
+  # ```
 
   lifecycle: {}
-  # To enable Graceful shutdown, Define a lifecycle preStop like bellow,
-  # Set the `terminationGracePeriodSeconds` to a value greater than or equal to the configured `shutdown.grace-period`.
-  # Configure `shutdown.grace-period` in `additionalConfigProperties` as `shutdown.grace-period=2m` (default is 2 minutes).
-  # Allow the operation on `accessControl` because isn't allow by default.
-  # Check the documentaion on https://trino.io/docs/current/admin/graceful-shutdown.html
+  # worker.lifecycle -- To enable [graceful
+  # shutdown](https://trino.io/docs/current/admin/graceful-shutdown.html),
+  # define a lifecycle preStop like bellow, Set the
+  # `terminationGracePeriodSeconds` to a value greater than or equal to the
+  # configured `shutdown.grace-period`. Configure `shutdown.grace-period` in
+  # `additionalConfigProperties` as `shutdown.grace-period=2m` (default is 2
+  # minutes). Also configure `accessControl` because the `default` system
+  # access control does not allow graceful shutdowns.
+  # @raw
+  # Example:
+  # ```yaml
   #  preStop:
   #    exec:
   #      command: ["/bin/sh", "-c", "curl -v -X PUT -d '\"SHUTTING_DOWN\"' -H \"Content-type: application/json\" http://localhost:8081/v1/info/state"]
+  # ```
 
   terminationGracePeriodSeconds: 30
 
@@ -399,29 +512,46 @@ worker:
   additionalConfigFiles: {}
 
   additionalVolumes: []
-  # One or more additional volume mounts to add to all workers.
+  # worker.additionalVolumes -- One or more additional volume mounts to add to all workers.
+  # @raw
+  # Example:
+  # ```yaml
   #  - name: extras
   #    emptyDir: {}
+  # ```
 
   additionalVolumeMounts: []
-  # One or more additional volume mounts to add to all workers.
+  # worker.additionalVolumeMounts -- One or more additional volume mounts to add to all workers.
+  # @raw
+  # Example:
+  # ```yaml
   #  - name: extras
   #    mountPath: /usr/share/extras
   #    readOnly: true
+  # ```
 
   annotations: {}
 
   labels: {}
 
   secretMounts: []
+  # worker.secretMounts -- Allows mounting additional Trino configuration
+  # files from Kubernetes secrets on all worker nodes.
+  # @raw
+  # Example:
+  # ```yaml
   #  - name: sample-secret
   #    secretName: sample-secret
   #    path: /secrets/sample.json
+  # ```
 
 kafka:
   mountPath: "/etc/trino/schemas"
   tableDescriptions: {}
-  # Custom kafka table descriptions that will be mounted in mountPath
+  # kafka.tableDescriptions -- Custom kafka table descriptions that will be mounted in mountPath.
+  # @raw
+  # Example:
+  # ```yaml
   #  testschema.json: |-
   #    {
   #      "tableName": "testtable",
@@ -454,19 +584,34 @@ kafka:
   #        ]
   #      }
   #    }
+  # ```
 
-# Labels that get applied to every resource's metadata
+# -- Labels that get applied to every resource's metadata
 commonLabels: {}
+
 ingress:
   enabled: false
   className: ""
   annotations: {}
   hosts: []
+  # ingress.hosts -- [Ingress
+  # rules](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules).
+  # @raw
+  # Example:
+  # ```yaml
   #  - host: trino.example.com
   #    paths:
   #      - path: /
   #        pathType: ImplementationSpecific
+  # ```
   tls: []
+  # ingress.tls -- Ingress
+  # [TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
+  # configuration.
+  # @raw
+  # Example:
+  # ```yaml
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  # ```


### PR DESCRIPTION
Use `pre-commit` so developers can use a git hook to regenerate docs.

I replaced `frigate` with `helm-docs` because frigate's pre-commit hook requires `conda` to install it. `helm-docs` run from a Docker container.

Also update all GitHub actions and enable Dependabot.