### PR TITLE
Always prefix configmap names with chart fullname

### DIFF
--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -57,9 +57,25 @@ Create chart name and version as used by the chart label.
 {{- end }}
 {{- end }}
 
+{{- define "trino.accessControl" -}}
+{{ template "trino.fullname" . }}-access-control-volume-coordinator
+{{- end -}}
+
 
 {{- define "trino.catalog" -}}
 {{ template "trino.fullname" . }}-catalog
+{{- end -}}
+
+{{- define "trino.resourceGroups" -}}
+{{ template "trino.fullname" . }}-resource-groups-volume-coordinator
+{{- end -}}
+
+{{- define "trino.schemasCoordinator" -}}
+{{ template "trino.fullname" . }}-schemas-volume-coordinator
+{{- end -}}
+
+{{- define "trino.schemasWorker" -}}
+{{ template "trino.fullname" . }}-schemas-volume-worker
 {{- end -}}
 
 {{/*

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -133,7 +133,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: trino-access-control-volume-coordinator
+  name: {{ template "trino.accessControl" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}
@@ -148,7 +148,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: trino-resource-groups-volume-coordinator
+  name: {{ template "trino.resourceGroups" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}
@@ -161,7 +161,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: schemas-volume-coordinator
+  name: {{ template "trino.schemasCoordinator" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -91,7 +91,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: schemas-volume-worker
+  name: {{ template "trino.schemasWorker" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -56,16 +56,16 @@ spec:
             name: {{ template "trino.catalog" . }}
         - name: schemas-volume
           configMap:
-            name: schemas-volume-coordinator
+            name: {{ template "trino.schemasCoordinator" . }}
         {{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
         - name: access-control-volume
           configMap:
-            name: trino-access-control-volume-coordinator
+            name: {{ template "trino.accessControl" . }}
         {{- end }}{{- end }}
         {{- if .Values.resourceGroups }}
         - name: resource-groups-volume
           configMap:
-            name: trino-resource-groups-volume-coordinator
+            name: {{ template "trino.resourceGroups" . }}
         {{- end }}
         {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret .Values.auth.groups }}
         - name: file-authentication-volume

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -58,7 +58,7 @@ spec:
             name: {{ template "trino.catalog" . }}
         - name: schemas-volume
           configMap:
-            name: schemas-volume-worker
+            name: {{ template "trino.schemasWorker" . }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:


### PR DESCRIPTION
Similar to #109 this removes a fixed name from remaining ConfigMaps.

This is intended to allow multiple Trino deployments within the same Kubernetes namespace. This is helpful for testing and other automation where it may not be practical to make a separate namespace for each deployment.

_I've followed the existing convention as used in the catalog helper. However, I wonder if this may cause ConfigMap names to exceed the max length in some cases?_