### PR TITLE
Fix nil pointer evaluating interface

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.0
+version: 0.23.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 449](https://img.shields.io/badge/AppVersion-449-informational?style=flat-square)
+![Version: 0.23.1](https://img.shields.io/badge/Version-0.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 449](https://img.shields.io/badge/AppVersion-449-informational?style=flat-square)
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe
 

--- a/charts/trino/templates/ingress.yaml
+++ b/charts/trino/templates/ingress.yaml
@@ -30,9 +30,9 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "trino.fullname" . }}
+                name: {{ include "trino.fullname" $ }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -139,3 +139,11 @@ accessControl:
           }
         ]
       }
+
+ingress:
+  enabled: true
+  hosts:
+    - host: trino.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific


### PR DESCRIPTION
Upgrading to 0.23.0, I get this error 

```
Error: template: trino/templates/ingress.yaml:33:25: executing "trino/templates/ingress.yaml" at <include "trino.fullname" .>: error calling include: template: trino/templates/_helpers.tpl:15:14: executing "trino.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
helm.go:84: [debug] template: trino/templates/ingress.yaml:33:25: executing "trino/templates/ingress.yaml" at <include "trino.fullname" .>: error calling include: template: trino/templates/_helpers.tpl:15:14: executing "trino.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```

This PR aims to fix nil pointer evaluating interface, by using $, which references the global scope in order to access the Values as expected.