### PR TITLE
Fix deleting CRDs at the end of tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -110,7 +110,10 @@ done
 if [ "$CLEANUP_NAMESPACE" == "true" ]; then
     helm -n "$NAMESPACE" uninstall prometheus-operator --ignore-not-found
     kubectl delete namespace "$NAMESPACE"
-    kubectl delete crd $(kubectl api-resources --api-group=monitoring.coreos.com --output name)
+    mapfile -t crds < <(kubectl api-resources --api-group=monitoring.coreos.com --output name)
+    if [ ${#crds[@]} -ne 0 ]; then
+        kubectl delete crd "${crds[@]}"
+    fi
 fi
 
 exit $result


### PR DESCRIPTION
When running tests except `complete_values`, when the Prometheus Operator is not being installed, there are no extra CRDs to remove, and the delete command was failing. Check explicitly if there's anything to remove. 