### PR TITLE
Update app and chart versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ct install
 
 To run tests with specific values:
 ```console
-ct install --helm-extra-set-args "--set image.tag=449"
+ct install --helm-extra-set-args "--set image.tag=450"
 ```
 
 Use the `test.sh` script to run a suite of tests, with different chart values.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can then run `helm search repo trino` to see the charts.
 Then you can install chart using:
 
 ```console
-helm install my-trino trino/trino --version 0.24.0
+helm install my-trino trino/trino --version 0.25.0
 ```
 
 Also, you can check the manifests using:

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.24.0
+version: 0.25.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.24.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # Same value as in values.yml#image.tag
-appVersion: "449"
+appVersion: "450"
 
 icon: https://trino.io/assets/trino.png
 

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 449](https://img.shields.io/badge/AppVersion-449-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 450](https://img.shields.io/badge/AppVersion-450-informational?style=flat-square)
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe
 

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 450](https://img.shields.io/badge/AppVersion-450-informational?style=flat-square)
+![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 450](https://img.shields.io/badge/AppVersion-450-informational?style=flat-square)
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe
 

--- a/charts/trino/templates/tests/test-jmx.yaml
+++ b/charts/trino/templates/tests/test-jmx.yaml
@@ -16,7 +16,7 @@ spec:
       image: {{ include "trino.image" . }}
       command: ["/bin/bash", "-c"]
       args:
-      - curl -s {{ include "trino.fullname" . }}.{{ .Release.Namespace }}:5556 | grep -q trino
+      - curl -s {{ include "trino.fullname" . }}.{{ .Release.Namespace }}:5556/metrics | grep -q trino
     {{- end }}
     {{- if .Values.serviceMonitor.enabled }}
     - name: service-monitor


### PR DESCRIPTION
Update Trino to 450, which is the latest available now.