### PR TITLE
Add https port to the service

### DIFF
--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -14,6 +14,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.server.config.https.enabled }}
+    - port: {{ .Values.server.config.https.port }}
+      targetPort: {{ .Values.server.config.https.port }}
+      protocol: TCP
+      name: https
+    {{- end }}
     {{- if .Values.jmx.exporter.enabled }}
     - port: {{ .Values.jmx.exporter.port }}
       targetPort: jmx-exporter


### PR DESCRIPTION
When we configure https in helm, it is not configured in the service, requiring a patch manually. This proposal comes so that when we configure HTTPS, it will be configured in the service.