### PR TITLE
URL handling for security.config-file on access-control.properties

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -80,14 +80,27 @@ data:
     {{- .Values.server.coordinatorExtraConfig | nindent 4 }}
     {{- end }}
 
-{{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
+{{ if .Values.accessControl }}
+{{- if and (eq .Values.accessControl.type "remote") (.Values.accessControl.url) }}
+  access-control.properties: |
+    access-control.name=file
+    {{- if .Values.accessControl.refreshPeriod }}
+    security.refresh-period={{ .Values.accessControl.refreshPeriod }}
+    {{- end }}
+    security.config-file={{ .Values.accessControl.url }}
+    {{- if .Values.accessControl.jsonPointer }}
+    security.json-pointer={{ .Values.accessControl.jsonPointer }}
+    {{- end }}
+{{- end }}
+{{- if eq .Values.accessControl.type "configmap" }}
   access-control.properties: |
     access-control.name=file
     {{- if .Values.accessControl.refreshPeriod }}
     security.refresh-period={{ .Values.accessControl.refreshPeriod }}
     {{- end }}
     security.config-file={{ .Values.server.config.path }}/access-control/{{ .Values.accessControl.configFile | default "rules.json" }}
-{{- end }}{{- end }}
+{{- end }}
+{{- end }}
 
 {{- if .Values.resourceGroups }}
   resource-groups.properties: |

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -91,8 +91,9 @@ accessControl: {}
 # accessControl -- [System access
 # control](https://trino.io/docs/current/security/built-in-system-access-control.html)
 # configuration.
+# type can be either 'configmap' when using a local file or 'remote' when using a file from an http/https URL
 # @raw
-# Example:
+# Example with configmap:
 # ```yaml
 #  type: configmap
 #  refreshPeriod: 60s
@@ -143,6 +144,14 @@ accessControl: {}
 #          }
 #        ]
 #      }
+# ```
+# Example with remote:
+# ```yaml
+#  type: "remote"
+#  refreshPeriod: "60s"
+#  url: "http://trino-test/config"
+#  jsonPointer: "/data"
+#  # Rules file is mounted to /etc/trino/access-control
 # ```
 
 resourceGroups: {}


### PR DESCRIPTION
When using ACLs, handle both a local file and a remote URL