### PR TITLE
feat: added ability to define the nodePort in the trino service

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -309,6 +309,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `service.annotations` - object, default: `{}`
 * `service.type` - string, default: `"ClusterIP"`
 * `service.port` - int, default: `8080`
+* `service.nodePort` - string, default: `""`  
+
+  The port the service listens on the host, for NodePort type. If not set, Kubernetes will [allocate a port automatically](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport-custom-port).
 * `auth` - object, default: `{}`  
 
   Available authentication methods.

--- a/charts/trino/templates/service.yaml
+++ b/charts/trino/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
     {{- if .Values.jmx.exporter.enabled }}
     - port: {{ .Values.jmx.exporter.port }}
       targetPort: jmx-exporter

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -348,6 +348,8 @@ service:
   annotations: {}
   type: ClusterIP
   port: 8080
+  # service.nodePort -- The port the service listens on the host, for NodePort type. If not set, Kubernetes will [allocate a port automatically](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport-custom-port).
+  nodePort: ""
 
 auth: {}
 # auth -- Available authentication methods.

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -21,6 +21,9 @@ additionalConfigProperties:
 service:
   annotations:
     custom/name: value
+  type: NodePort
+  port: 8080
+  nodePort: 30080
 
 auth:
   # created using htpasswd -B -C 10 password.db admin


### PR DESCRIPTION
Hello.

This PR is to be able to customize the NodePort in the Trino service.

I adjusted it due to the issue https://github.com/trinodb/charts/issues/203.