### PR TITLE
Allow using custom accessControl (eg. OPA)

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -86,7 +86,17 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `accessControl` - object, default: `{}`  
 
   [System access control](https://trino.io/docs/current/security/built-in-system-access-control.html) configuration.
-  Example:
+  Set the type property to either:
+  * `configmap`, and provide the rule file contents in `rules`,
+  * `properties`, and provide configuration properties in `properties`.
+  Properties example:
+  ```yaml
+  type: properties
+  properties: |
+      access-control.name=custom-access-control
+      access-control.custom_key=custom_value
+  ```
+  Config map example:
   ```yaml
    type: configmap
    refreshPeriod: 60s

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -80,14 +80,25 @@ data:
     {{- .Values.server.coordinatorExtraConfig | nindent 4 }}
     {{- end }}
 
-{{- if .Values.accessControl }}{{- if eq .Values.accessControl.type "configmap" }}
+{{- if .Values.accessControl }}
+  {{- if eq .Values.accessControl.type "configmap" }}
   access-control.properties: |
     access-control.name=file
     {{- if .Values.accessControl.refreshPeriod }}
     security.refresh-period={{ .Values.accessControl.refreshPeriod }}
     {{- end }}
     security.config-file={{ .Values.server.config.path }}/access-control/{{ .Values.accessControl.configFile | default "rules.json" }}
-{{- end }}{{- end }}
+  {{- else if eq .Values.accessControl.type "properties" }}
+  access-control.properties: |
+    {{- if .Values.accessControl.properties }}
+    {{- .Values.accessControl.properties | nindent 4 }}
+    {{- else}}
+    {{- fail "accessControl.properties is required when accessControl.type is 'properties'." }}
+    {{- end }}
+  {{- else}}
+  {{- fail "Invalid accessControl.type value. It must be either 'configmap' or 'properties'." }}
+  {{- end }}
+{{- end }}
 
 {{- if .Values.resourceGroups }}
   resource-groups.properties: |

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -92,7 +92,17 @@ accessControl: {}
 # control](https://trino.io/docs/current/security/built-in-system-access-control.html)
 # configuration.
 # @raw
-# Example:
+# Set the type property to either:
+# * `configmap`, and provide the rule file contents in `rules`,
+# * `properties`, and provide configuration properties in `properties`.
+# Properties example:
+# ```yaml
+# type: properties
+# properties: |
+#     access-control.name=custom-access-control
+#     access-control.custom_key=custom_value
+# ```
+# Config map example:
 # ```yaml
 #  type: configmap
 #  refreshPeriod: 60s

--- a/test-access-control-properties-values.yaml
+++ b/test-access-control-properties-values.yaml
@@ -1,0 +1,7 @@
+# Access Control 'properties' values to test.
+# This is a YAML-formatted file.
+
+accessControl:
+  type: properties
+  properties: |
+    access-control.name=read-only

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,7 @@ declare -A testCases=(
     [single_node]="--set server.workers=0"
     [complete_values]="--values test-values.yaml"
     [overrides]="--set coordinatorNameOverride=coordinator-overridden,workerNameOverride=worker-overridden,nameOverride=overridden"
+    [access_control_properties_values]="--values test-access-control-properties-values.yaml"
 )
 
 function join_by {
@@ -21,7 +22,7 @@ NAMESPACE=trino-$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 6 || true)
 HELM_EXTRA_SET_ARGS=
 CT_ARGS=(--charts=charts/trino --skip-clean-up --helm-extra-args="--timeout 2m")
 CLEANUP_NAMESPACE=true
-TEST_NAMES=(default single_node complete_values)
+TEST_NAMES=(default single_node complete_values access_control_properties_values)
 
 usage() {
     cat <<EOF 1>&2


### PR DESCRIPTION
This PR is the conclusion of [this PR](https://github.com/trinodb/charts/pull/88).

Adds the ability to use custom access control (eg. Open Policy Agent).