### PR TITLE
add check if passwordAuthSecret is using

### DIFF
--- a/charts/trino/templates/secret.yaml
+++ b/charts/trino/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.auth.passwordAuth .Values.auth.groups }}
+{{- if and (not .Values.auth.passwordAuthSecret) (or .Values.auth.passwordAuth .Values.auth.groups)  }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Add check if 
`Values.auth.passwordAuthSecret` is set together with `Values.auth.groups`  and don't make secret with the name `trino.fileAuthSecretName`  
But retain the code to import this as volume.