### PR TITLE
Make exchange manager conditional

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -54,8 +54,25 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 
   Trino supports multiple [authentication types](https://trino.io/docs/current/security/authentication-types.html): PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS.
 * `server.config.query.maxMemory` - string, default: `"4GB"`
-* `server.exchangeManager.name` - string, default: `"filesystem"`
-* `server.exchangeManager.baseDir` - string, default: `"/tmp/trino-local-file-system-exchange-manager"`
+* `server.exchangeManager` - object, default: `{}`  
+
+  Mandatory [exchange manager configuration](https://trino.io/docs/current/admin/fault-tolerant-execution.html#id1).
+  Used to set the name and location(s) of the spooling storage destination.
+  * To enable fault-tolerant execution, you must set the `retry-policy` property in `additionalConfigProperties`.
+  * Additional exchange manager configurations can be added to `additionalExchangeManagerProperties`.
+  Example:
+  ```yaml
+   server:
+     exchangeManager:
+       name: "filesystem"
+       baseDir: "/tmp/trino-local-file-system-exchange-manager"
+   additionalConfigProperties:
+    - retry-policy=TASK
+  additionalExchangeManagerProperties:
+    - exchange.sink-buffer-pool-min-size=10
+    - exchange.sink-buffers-per-partition=2
+    - exchange.source-concurrent-readers=4
+  ```
 * `server.workerExtraConfig` - string, default: `""`
 * `server.coordinatorExtraConfig` - string, default: `""`
 * `server.autoscaling.enabled` - bool, default: `false`

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -106,14 +106,14 @@ data:
     resource-groups.config-file={{ .Values.server.config.path }}/resource-groups/resource-groups.json
 {{- end }}
 
+{{- if .Values.server.exchangeManager }}
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}
-  {{ if eq .Values.server.exchangeManager.name "filesystem" }}
     exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
-  {{- end }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
     {{ $configValue }}
   {{- end }}
+{{- end }}
 
   log.properties: |
     io.trino={{ .Values.server.log.trino.level }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -61,14 +61,14 @@ data:
     {{- .Values.server.workerExtraConfig | nindent 4 }}
     {{- end }}
 
+{{- if .Values.server.exchangeManager }}
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}
-  {{ if eq .Values.server.exchangeManager.name "filesystem" }}
     exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
-  {{- end }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
     {{ $configValue }}
   {{- end }}
+{{- end }}
 
   log.properties: |
     io.trino={{ .Values.server.log.trino.level }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -55,9 +55,27 @@ server:
     authenticationType: ""
     query:
       maxMemory: "4GB"
-  exchangeManager:
-    name: "filesystem"
-    baseDir: "/tmp/trino-local-file-system-exchange-manager"
+  exchangeManager: {}
+  # server.exchangeManager -- Mandatory [exchange manager
+  # configuration](https://trino.io/docs/current/admin/fault-tolerant-execution.html#id1).
+  # @raw
+  # Used to set the name and location(s) of the spooling storage destination.
+  # * To enable fault-tolerant execution, you must set the `retry-policy` property in `additionalConfigProperties`.
+  # * Additional exchange manager configurations can be added to `additionalExchangeManagerProperties`.
+  # Example:
+  # ```yaml
+  #  server:
+  #    exchangeManager:
+  #      name: "filesystem"
+  #      baseDir: "/tmp/trino-local-file-system-exchange-manager"
+  #  additionalConfigProperties:
+  #   - retry-policy=TASK
+  # additionalExchangeManagerProperties:
+  #   - exchange.sink-buffer-pool-min-size=10
+  #   - exchange.sink-buffers-per-partition=2
+  #   - exchange.source-concurrent-readers=4
+  # ```
+
   workerExtraConfig: ""
   coordinatorExtraConfig: ""
   autoscaling:

--- a/test-exchange-manager-values.yaml
+++ b/test-exchange-manager-values.yaml
@@ -1,0 +1,35 @@
+# Exchange Manager values to test.
+# This is a YAML-formatted file.
+
+coordinator:
+  additionalVolumes:
+    - name: exchange-volume
+      persistentVolumeClaim:
+        claimName: exchange-manager-pvc
+
+  additionalVolumeMounts:
+    - name: exchange-volume
+      mountPath: "/tmp/trino-local-file-system-exchange-manager"
+
+worker:
+  additionalVolumes:
+    - name: exchange-volume
+      persistentVolumeClaim:
+        claimName: exchange-manager-pvc
+
+  additionalVolumeMounts:
+    - name: exchange-volume
+      mountPath: "/tmp/trino-local-file-system-exchange-manager"
+
+server:
+  exchangeManager:
+    name: "filesystem"
+    baseDir: "/tmp/trino-local-file-system-exchange-manager"
+
+additionalConfigProperties:
+  - retry-policy=TASK
+
+additionalExchangeManagerProperties:
+  - exchange.sink-buffer-pool-min-size=10
+  - exchange.sink-buffers-per-partition=2
+  - exchange.source-concurrent-readers=4


### PR DESCRIPTION
Currently the exchange manager properties file is always created via Helm chart although this is considered as an optional configuration in Trino. In this PR I made its creation conditional according to whether or not the `.Values.server.exchangeManager` was set.

I also removed the condition in its properties file, that links between `exchamge-manager.name=filesystem` to  `exchange.base-directories` existence, as they are not dependent (you can see [here](https://trino.io/docs/current/admin/fault-tolerant-execution.html#id1) that this configuration supports also `hdfs` as the value of `exchamge-manager.name`).

**Note:**
1. I was thinking of uniting `.Values.server.exchangeManager` and `.Values.server.additionalExchangeManagerProperties` as it seems more convenient to have all the exchange manager configurations in the same place, but then I noticed it's being done the same way in other places, such as `log.properties` and `node.properties`, so I kept it for now.
2. I didn't figure out how to include the description I added to the values file in the `README.md`. I found that only some things where generated via the pre-commit, but not all of them, help would be appreciated.