### PR TITLE
Support templated values in coordinator and worker configmaps

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -12,7 +12,7 @@ data:
     node.data-dir={{ .Values.server.node.dataDir }}
     plugin.dir={{ .Values.server.node.pluginDir }}
   {{- range $configValue := .Values.additionalNodeProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 
   jvm.config: |
@@ -41,7 +41,7 @@ data:
   {{- end }}{{/* if */}}
   {{- end }}{{/* with */}}
   {{- range $configValue := .Values.coordinator.additionalJVMConfig }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
   {{- if .Values.jmx.enabled }}
     -Dcom.sun.management.jmxremote.rmi.port={{ .Values.jmx.serverPort }}
@@ -65,7 +65,7 @@ data:
     http-server.authentication.type={{ .Values.server.config.authenticationType }}
     {{- end }}
     {{- range $configValue := .Values.additionalConfigProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
     {{- end }}
     {{- if .Values.server.config.https.enabled }}
     http-server.https.enabled=true
@@ -77,7 +77,7 @@ data:
     jmx.rmiserver.port={{ .Values.jmx.serverPort }}
     {{- end }}
     {{- if .Values.server.coordinatorExtraConfig }}
-    {{- .Values.server.coordinatorExtraConfig | nindent 4 }}
+    {{- tpl .Values.server.coordinatorExtraConfig $ | nindent 4 }}
     {{- end }}
 
 {{- if .Values.accessControl }}
@@ -91,7 +91,7 @@ data:
   {{- else if eq .Values.accessControl.type "properties" }}
   access-control.properties: |
     {{- if .Values.accessControl.properties }}
-    {{- .Values.accessControl.properties | nindent 4 }}
+    {{- tpl .Values.accessControl.properties $ | nindent 4 }}
     {{- else}}
     {{- fail "accessControl.properties is required when accessControl.type is 'properties'." }}
     {{- end }}
@@ -112,13 +112,13 @@ data:
     exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
   {{- end }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 
   log.properties: |
     io.trino={{ .Values.server.log.trino.level }}
   {{- range $configValue := .Values.additionalLogProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 
   {{- if contains "PASSWORD" .Values.server.config.authenticationType }}
@@ -138,13 +138,13 @@ data:
 {{ if .Values.eventListenerProperties }}
   event-listener.properties: |
   {{- range $configValue := .Values.eventListenerProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 {{ end }}
 
 {{- range $fileName, $fileContent := .Values.coordinator.additionalConfigFiles }}
   {{ $fileName }}: |
-    {{- $fileContent | nindent 4 }}
+    {{- tpl $fileContent $ | nindent 4 }}
 {{- end }}
 
 ---
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/component: coordinator
 data:
   {{- range $key, $val := .Values.accessControl.rules }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ tpl $val $ | quote }}
   {{- end }}
 {{- end }}{{- end }}
 {{- if .Values.resourceGroups }}
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/component: coordinator
 data:
   resource-groups.json: |-
-    {{- .Values.resourceGroups.resourceGroupsConfig | nindent 4 }}
+    {{- tpl .Values.resourceGroups.resourceGroupsConfig $ | nindent 4 }}
 {{- end }}
 ---
 apiVersion: v1
@@ -188,5 +188,5 @@ metadata:
     app.kubernetes.io/component: coordinator
 data:
   {{- range $key, $val := .Values.kafka.tableDescriptions }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ tpl $val $ | quote }}
   {{- end }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -13,7 +13,7 @@ data:
     node.data-dir={{ .Values.server.node.dataDir }}
     plugin.dir={{ .Values.server.node.pluginDir }}
   {{- range $configValue := .Values.additionalNodeProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 
   jvm.config: |
@@ -42,7 +42,7 @@ data:
   {{- end }}{{/* if */}}
   {{- end }}{{/* with */}}
   {{- range $configValue := .Values.worker.additionalJVMConfig }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 
   config.properties: |
@@ -55,10 +55,10 @@ data:
     {{- end }}
     discovery.uri=http://{{ template "trino.fullname" . }}:{{ .Values.service.port }}
     {{- range $configValue := .Values.additionalConfigProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
     {{- end }}
     {{- if .Values.server.workerExtraConfig }}
-    {{- .Values.server.workerExtraConfig | nindent 4 }}
+    {{- tpl .Values.server.workerExtraConfig $ | nindent 4 }}
     {{- end }}
 
   exchange-manager.properties: |
@@ -67,25 +67,25 @@ data:
     exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
   {{- end }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 
   log.properties: |
     io.trino={{ .Values.server.log.trino.level }}
   {{- range $configValue := .Values.additionalLogProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 
 {{ if .Values.eventListenerProperties }}
   event-listener.properties: |
   {{- range $configValue := .Values.eventListenerProperties }}
-    {{ $configValue }}
+    {{ tpl $configValue $ }}
   {{- end }}
 {{ end }}
 
 {{- range $fileName, $fileContent := .Values.worker.additionalConfigFiles }}
   {{ $fileName }}: |
-    {{- $fileContent | nindent 4 }}
+    {{- tpl $fileContent $ | nindent 4 }}
 {{- end }}
 ---
 apiVersion: v1
@@ -98,6 +98,6 @@ metadata:
     app.kubernetes.io/component: worker
 data:
   {{- range $key, $val := .Values.kafka.tableDescriptions }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ tpl $val $ | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The chart currently does not support using templated `.Values`, i.e, values which include `{{ template "..." . }}`, `{{ .Files.Get ... }}` etc. won't render.

My use case was that I had `additionalConfigFiles` which were quite lengthy, so I didn't want to include their content in the values file, hence decided to read them from some configs directory instead.

For example, in the values I had:
```yaml
additionalConfigFiles:
  some-file.txt: |
    {{ .Files.Get "test-file.txt" }}
```
After I deployed the chart, I found that the file content was simply `{{ .Files.Get "test-file.txt" }}` (not rendered).

The following changes solve that for both `configmap-coordinator.yaml` and `configmap-worker.yaml`,
so that you can use some templated values there (added that support only for the values that seem relevant to me).
This change can be applied across all the project manifests, but for now I've only applied it on 2.