### PR TITLE
Support custom password auth properties file

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -121,11 +121,12 @@ data:
     {{ $configValue }}
   {{- end }}
 
-  {{- if contains "PASSWORD" .Values.server.config.authenticationType }}
+  {{- if contains "PASSWORD" .Values.server.config.authenticationType }}{{- if not (index .Values.coordinator.additionalConfigFiles "password-authenticator.properties") }}
   password-authenticator.properties: |
     password-authenticator.name=file
     file.password-file={{ .Values.server.config.path }}/auth/password.db
-  {{- end }}
+  {{- end }}{{- end }}
+
   {{- if .Values.auth.groups }}{{- if not (index .Values.coordinator.additionalConfigFiles "group-provider.properties") }}
   group-provider.properties: |
     group-provider.name=file


### PR DESCRIPTION
As for now, one you've set your auth type to `"PASSWORD"` via `Values.server.config.authenticationType`, you are forced to use a[ specific conf file](https://github.com/trinodb/charts/blob/main/charts/trino/templates/configmap-coordinator.yaml#L125) set for [password file auth](https://trino.io/docs/current/security/password-file.html).

This implementation restricts auth configurations in the following ways:

1. It restricts the usage of configurations specific to that auth implementation (e.g., we cannot configure `file.auth-token-cache.max-size`).
2. Even worse, it does not allow configuring LDAP properties, which should also be enabled by the `"PASSWORD"` auth type.

This PR suggests a  small fix to address these scenarios.