### PR TITLE
Fix JMX Exporter container port spec

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -656,12 +656,13 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `jmx.exporter.image` - string, default: `"bitnami/jmx-exporter:latest"`
 * `jmx.exporter.pullPolicy` - string, default: `"Always"`
 * `jmx.exporter.port` - int, default: `5556`
-* `jmx.exporter.configProperties` - list, default: `[]`  
+* `jmx.exporter.configProperties` - string, default: `""`  
 
-  JMX Config Properties is mounted to /etc/jmx-exporter/jmx-exporter-config.yaml
+  The string value is templated using `tpl`. JMX Config Properties is mounted to /etc/jmx-exporter/jmx-exporter-config.yaml
   Example:
   ```yaml
    configProperties: |-
+      hostPort: localhost:{{- .Values.jmx.registryPort }}
       startDelaySeconds: 0
       ssl: false
       lowercaseOutputName: false

--- a/charts/trino/templates/configmap-jmx-exporter.yaml
+++ b/charts/trino/templates/configmap-jmx-exporter.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jmx.exporter.enabled -}}
+{{- if .Values.jmx.exporter.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,5 +9,5 @@ metadata:
     app.kubernetes.io/component: jmx
 data:
   jmx-exporter-config.yaml: |-
-    {{- .Values.jmx.exporter.configProperties | nindent 4 }}
+    {{- tpl .Values.jmx.exporter.configProperties . | nindent 4 }}
 {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -162,18 +162,15 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-            {{- if .Values.jmx.enabled }}
+            {{- with .Values.jmx }}
+            {{- if .enabled }}
             - name: jmx-registry
-              containerPort: {{ .Values.jmx.registryPort }}
+              containerPort: {{ .registryPort }}
               protocol: TCP
             - name: jmx-server
-              containerPort: {{ .Values.jmx.serverPort }}
+              containerPort: {{ .serverPort }}
               protocol: TCP
             {{- end }}
-            {{- if .Values.jmx.exporter.enabled }}
-            - name: jmx-exporter
-              containerPort: {{ .Values.jmx.exporter.port }}
-              protocol: TCP
             {{- end }}
           {{- range $key, $value := .Values.coordinator.additionalExposedPorts }}
             - name: {{ $value.name }}
@@ -201,22 +198,30 @@ spec:
             {{- toYaml .Values.coordinator.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.coordinator.resources | nindent 12 }}
-      {{- if .Values.jmx.exporter.enabled }}
+      {{- with .Values.jmx.exporter }}
+      {{- if .enabled }}
         - name: jmx-exporter
-          image: {{ .Values.jmx.exporter.image }}
-          imagePullPolicy: {{ .Values.jmx.exporter.pullPolicy }}
-          {{- with .Values.jmx.exporter.securityContext }}
+          image: {{ .image }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- with .securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - "{{ .Values.jmx.exporter.port }}"
+            - "{{ .port }}"
             - /etc/jmx-exporter/jmx-exporter-config.yaml
           volumeMounts:
             - mountPath: /etc/jmx-exporter/
               name: jmx-exporter-config-volume
+          {{- with .resources }}
           resources:
-            {{- toYaml .Values.jmx.exporter.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: jmx-exporter
+              containerPort: {{ .port }}
+              protocol: TCP
+      {{- end }}
       {{- end }}
       {{- if .Values.sidecarContainers.coordinator }}
         {{- toYaml .Values.sidecarContainers.coordinator | nindent 8 }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -779,13 +779,13 @@ jmx:
     image: bitnami/jmx-exporter:latest
     pullPolicy: Always
     port: 5556
-    configProperties: []
-    securityContext: {}
-    # jmx.exporter.configProperties -- JMX Config Properties is mounted to /etc/jmx-exporter/jmx-exporter-config.yaml
+    configProperties: ""
+    # jmx.exporter.configProperties -- The string value is templated using `tpl`. JMX Config Properties is mounted to /etc/jmx-exporter/jmx-exporter-config.yaml
     # @raw
     # Example:
     # ```yaml
     #  configProperties: |-
+    #     hostPort: localhost:{{- .Values.jmx.registryPort }}
     #     startDelaySeconds: 0
     #     ssl: false
     #     lowercaseOutputName: false
@@ -804,6 +804,7 @@ jmx:
     #         value: '$2'
     #         help: 'ThreadCount (java.lang<type=Threading><>ThreadCount)'
     #         type: UNTYPED
+    securityContext: {}
     resources: {}
     # jmx.exporter.resources -- It is recommended not to specify default resources
     # and to leave this as a conscious choice for the user. This also increases


### PR DESCRIPTION
I moved the JMX Exporter container port to correct container (previously located on the coordinator container), with a minor.

Also, the property `.Values.jmx.exporter.configProperties` was declared as a list which was incorrect. I converted it to a templated multiline string.

I also updated the minimal JMX configuration example in the default value of `.Values.jmx.exporter.configProperties`.

Fixes #221 