### PR TITLE
Optional catalogs and related configmap

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -268,9 +268,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    - custom-property1=custom-value1
    - custom-property2=custom-value2
   ```
-* `additionalCatalogs` - object, default: `{}`  
+* `catalogs` - object, default: `{"tpcds":"connector.name=tpcds\ntpcds.splits-per-node=4\n","tpch":"connector.name=tpch\ntpch.splits-per-node=4\n"}`  
 
-  Configure additional [catalogs](https://trino.io/docs/current/installation/deployment.html#catalog-properties). The TPCH and TPCDS catalogs are always enabled by default, with 4 splits per node.
+  Configure [catalogs](https://trino.io/docs/current/installation/deployment.html#catalog-properties).
   Example:
   ```yaml
    objectstore: |
@@ -282,6 +282,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
      connector.name=memory
      memory.max-data-per-node=128MB
   ```
+* `additionalCatalogs` - object, default: `{}`  
+
+  Deprecated, use `catalogs` instead. Configure additional [catalogs](https://trino.io/docs/current/installation/deployment.html#catalog-properties).
 * `env` - list, default: `[]`  
 
   additional environment variables added to every pod, specified as a list with explicit values

--- a/charts/trino/templates/configmap-catalog.yaml
+++ b/charts/trino/templates/configmap-catalog.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.catalogs .Values.additionalCatalogs }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,13 +8,9 @@ metadata:
     {{- include "trino.labels" . | nindent 4 }}
     app.kubernetes.io/component: catalogs
 data:
-  tpch.properties: |
-    connector.name=tpch
-    tpch.splits-per-node=4
-  tpcds.properties: |
-    connector.name=tpcds
-    tpcds.splits-per-node=4
-{{- range $catalogName, $catalogProperties := .Values.additionalCatalogs }}
+{{- $merged := merge .Values.catalogs .Values.additionalCatalogs }}
+{{- range $catalogName, $catalogProperties := $merged }}
   {{ $catalogName }}.properties: |
     {{- $catalogProperties | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -20,7 +20,9 @@ spec:
         {{- if and (eq .Values.accessControl.type "configmap") (not .Values.accessControl.refreshPeriod) }}
         checksum/access-control-config: {{ include (print $.Template.BasePath "/configmap-access-control.yaml") . | sha256sum }}
         {{- end }}
+        {{- if or .Values.catalogs .Values.additionalCatalogs }}
         checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        {{- end }}
         checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}
       {{- if .Values.coordinator.annotations }}
       {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
@@ -45,9 +47,11 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "trino.coordinator" . }}
+        {{- if or .Values.catalogs .Values.additionalCatalogs }}
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
+        {{- end }}
         - name: schemas-volume
           configMap:
             name: {{ template "trino.fullname" . }}-schemas-volume-coordinator
@@ -123,8 +127,10 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume
+            {{- if or .Values.catalogs .Values.additionalCatalogs }}
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
+            {{- end }}
             - mountPath: {{ .Values.kafka.mountPath }}
               name: schemas-volume
             {{- if eq .Values.accessControl.type "configmap" }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -21,7 +21,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if or .Values.catalogs .Values.additionalCatalogs }}
         checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        {{- end }}
         checksum/worker-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
       {{- if .Values.worker.annotations }}
       {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
@@ -45,9 +47,11 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "trino.worker" . }}
+        {{- if or .Values.catalogs .Values.additionalCatalogs }}
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
+        {{- end }}
         - name: schemas-volume
           configMap:
             name: {{ template "trino.fullname" . }}-schemas-volume-worker
@@ -94,8 +98,10 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume
+            {{- if or .Values.catalogs .Values.additionalCatalogs }}
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
+            {{- end }}
             - mountPath: {{ .Values.kafka.mountPath }}
               name: schemas-volume
             {{- range .Values.configMounts }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -291,11 +291,15 @@ eventListenerProperties: []
 #  - custom-property2=custom-value2
 # ```
 
-additionalCatalogs: {}
-# additionalCatalogs -- Configure additional
+catalogs:
+  tpch: |
+    connector.name=tpch
+    tpch.splits-per-node=4
+  tpcds: |
+    connector.name=tpcds
+    tpcds.splits-per-node=4
+# catalogs -- Configure
 # [catalogs](https://trino.io/docs/current/installation/deployment.html#catalog-properties).
-# The TPCH and TPCDS catalogs are always enabled by default, with 4 splits per
-# node.
 # @raw
 # Example:
 # ```yaml
@@ -308,6 +312,10 @@ additionalCatalogs: {}
 #    connector.name=memory
 #    memory.max-data-per-node=128MB
 # ```
+
+additionalCatalogs: {}
+# additionalCatalogs -- Deprecated, use `catalogs` instead. Configure additional
+# [catalogs](https://trino.io/docs/current/installation/deployment.html#catalog-properties).
 
 env: []
 # env -- additional environment variables added to every pod, specified as a list with explicit values


### PR DESCRIPTION
I moved the default `tpch` and `tpcds` catalogs from the related configmap into a unified `catalogs` configuration where users will be able to remove them if neccessary.

If no catalogs are provided, the related configmap will not be created/mounted. 

This `additionalCatalogs` property has now been deprecated in favor of the newly introduced `catalogs`.

Fixes: #210