### PR TITLE
add_separate_group.db_secret

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -376,6 +376,10 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    refreshPeriod: 5s
    groups: "group_name:user_1,user_2,user_3"
   ```
+  Set the name of a secret containing this file in the group.db key
+  ```yaml
+   groupAuthSecret: "trino-group-authentication"
+  ```
 * `serviceAccount.create` - bool, default: `false`  
 
   Specifies whether a service account should be created

--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -125,17 +125,33 @@ Code is inspired from bitnami/common
 {{- end -}}
 
 {{/*
-Create the name of the file auth secret to use
+Create the secret name for the file-based authentication's password file
 */}}
-{{- define "trino.fileAuthSecretName" -}}
+{{- define "trino.passwordSecretName" -}}
 {{- if and .Values.auth .Values.auth.passwordAuthSecret }}
 {{- .Values.auth.passwordAuthSecret | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if hasPrefix .Release.Name $name }}
-{{- printf "%s-%s" $name "file-authentication" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" $name "password-file" | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s-%s" .Release.Name $name "file-authentication" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s-%s" .Release.Name $name "password-file" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the secret name for the group-provider file
+*/}}
+{{- define "trino.groupsSecretName" -}}
+{{- if and .Values.auth .Values.auth.groupAuthSecret }}
+{{- .Values.auth.groupAuthSecret | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if hasPrefix .Release.Name $name }}
+{{- printf "%s-%s" $name "groups-file" | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s-%s" .Release.Name $name "groups-file" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -128,13 +128,13 @@ data:
   {{- if contains "PASSWORD" .Values.server.config.authenticationType }}{{- if not (index .Values.coordinator.additionalConfigFiles "password-authenticator.properties") }}
   password-authenticator.properties: |
     password-authenticator.name=file
-    file.password-file={{ .Values.server.config.path }}/auth/password.db
+    file.password-file={{ .Values.server.config.path }}/auth/password/password.db
   {{- end }}{{- end }}
 
   {{- if .Values.auth.groups }}{{- if not (index .Values.coordinator.additionalConfigFiles "group-provider.properties") }}
   group-provider.properties: |
     group-provider.name=file
-    file.group-file={{ .Values.server.config.path }}/auth/group.db
+    file.group-file={{ .Values.server.config.path }}/auth/group/group.db
     {{- if .Values.auth.refreshPeriod }}
     file.refresh-period={{ .Values.auth.refreshPeriod }}
     {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -72,19 +72,21 @@ spec:
           configMap:
             name: {{ template "trino.fullname" . }}-resource-groups-volume-coordinator
         {{- end }}
-        {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret .Values.auth.groups }}
-        - name: file-authentication-volume
+        {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret }}
+        - name: file-password-authentication-volume
           secret:
-            secretName: {{ template "trino.fileAuthSecretName" . }}
+            secretName: {{ template "trino.passwordSecretName" . }}
             items:
-              {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret }}
               - key: password.db
                 path: password.db
-              {{- end }}
-              {{- if .Values.auth.groups }}
+        {{- end }}
+        {{- if or .Values.auth.groups .Values.auth.groupsAuthSecret }}
+        - name: file-groups-authentication-volume
+          secret:
+            secretName: {{ template "trino.groupsSecretName" . }}
+            items:
               - key: group.db
                 path: group.db
-              {{- end }}
         {{- end }}
         {{- if $coordinatorJmx.exporter.enabled }}
         - name: jmx-exporter-config-volume
@@ -166,9 +168,13 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .path }}
             {{- end }}
-            {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret .Values.auth.groups }}
-            - mountPath: {{ .Values.server.config.path }}/auth
-              name: file-authentication-volume
+            {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret }}
+            - mountPath: {{ .Values.server.config.path }}/auth/password
+              name: file-password-authentication-volume
+            {{- end }}
+            {{- if or .Values.auth.groups .Values.auth.groupsAuthSecret }}
+            - mountPath: {{ .Values.server.config.path }}/auth/group
+              name: file-groups-authentication-volume
             {{- end }}
             {{- with .Values.coordinator.additionalVolumeMounts }}
             {{- . | toYaml | nindent 12 }}

--- a/charts/trino/templates/secret.yaml
+++ b/charts/trino/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if or .Values.auth.passwordAuth .Values.auth.groups }}
+{{- if and (not .Values.auth.passwordAuthSecret) .Values.auth.passwordAuth }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "trino.fileAuthSecretName" . }}
+  name: {{ template "trino.passwordSecretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "trino.labels" . | nindent 4 }}
@@ -10,6 +10,17 @@ data:
 {{- if .Values.auth.passwordAuth }}
   password.db: {{ .Values.auth.passwordAuth | b64enc }}
 {{- end }}
+{{- end }}
+---
+{{- if and (not .Values.auth.groupsAuthSecret) .Values.auth.groups }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "trino.groupsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+data:
 {{- if .Values.auth.groups}}
   group.db: {{ .Values.auth.groups | b64enc }}
 {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -428,6 +428,10 @@ auth: {}
 #  refreshPeriod: 5s
 #  groups: "group_name:user_1,user_2,user_3"
 # ```
+# Set the name of a secret containing this file in the group.db key
+# ```yaml
+#  groupAuthSecret: "trino-group-authentication"
+# ```
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
Hello!
I'm not very experienced with Trino configuration, but I do have a bit more experience with Helm charts.
The main question in this PR is determining the correct place to change the file.password-file and file.group-file configurations.

I placed them in a separate folder to keep automatic updates when k8s secrets are updated.
This approach contrasts with using subPath, which does not support automatic file updates within pod volumes.

