### PR TITLE
Add spec values to coordinator and worker deployments

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -10,6 +10,16 @@ metadata:
     {{- tpl (toYaml .Values.coordinator.labels) . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.coordinator.deployment.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ .Values.coordinator.deployment.progressDeadlineSeconds }}
+  {{- end }}
+  {{- if or .Values.coordinator.deployment.revisionHistoryLimit (eq 0 .Values.coordinator.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.coordinator.deployment.revisionHistoryLimit }}
+  {{- end }}
+  {{- if .Values.coordinator.deployment.strategy }}
+  strategy:
+    {{- toYaml .Values.coordinator.deployment.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "trino.selectorLabels" . | nindent 6 }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -11,6 +11,16 @@ metadata:
     {{- tpl (toYaml .Values.worker.labels) . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.worker.deployment.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ .Values.worker.deployment.progressDeadlineSeconds }}
+  {{- end }}
+  {{- if or .Values.worker.deployment.revisionHistoryLimit (eq 0 .Values.worker.deployment.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.worker.deployment.revisionHistoryLimit }}
+  {{- end }}
+  {{- if .Values.worker.deployment.strategy }}
+  strategy:
+    {{- toYaml .Values.worker.deployment.strategy | nindent 4 }}
+  {{- end }}
   {{- if not .Values.server.autoscaling.enabled }}
   replicas: {{ .Values.server.workers }}
   {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -447,6 +447,15 @@ secretMounts: []
 # ```
 
 coordinator:
+  deployment:
+    progressDeadlineSeconds: ~
+    revisionHistoryLimit: ~
+    strategy: {}
+    #  rollingUpdate:
+    #    maxSurge: 25%
+    #    maxUnavailable: 25%
+    #  type: RollingUpdate
+
   jvm:
     maxHeapSize: "8G"
     gcMethod:
@@ -587,6 +596,15 @@ coordinator:
   #    path: /secrets/sample.json
 
 worker:
+  deployment:
+    progressDeadlineSeconds: ~
+    revisionHistoryLimit: ~
+    strategy: {}
+    #  rollingUpdate:
+    #    maxSurge: 25%
+    #    maxUnavailable: 25%
+    #  type: RollingUpdate
+
   jvm:
     maxHeapSize: "8G"
     gcMethod:


### PR DESCRIPTION
Adding deployment spec values for `coordinator` deployment and `worker` deployment:
```
 - progressDeadlineSeconds
 - revisionHistoryLimit
 - strategy
```
This is needed for us in case of an update of Trino Cluster that requires the deployment to bring pods up and down.