### PR TITLE
Allow autoscaling by memory utilization

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -83,7 +83,12 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `server.coordinatorExtraConfig` - string, default: `""`
 * `server.autoscaling.enabled` - bool, default: `false`
 * `server.autoscaling.maxReplicas` - int, default: `5`
-* `server.autoscaling.targetCPUUtilizationPercentage` - int, default: `50`
+* `server.autoscaling.targetCPUUtilizationPercentage` - int, default: `50`  
+
+  Target average CPU utilization, represented as a percentage of requested CPU. To disable scaling based on CPU, set to an empty string.
+* `server.autoscaling.targetMemoryUtilizationPercentage` - int, default: `80`  
+
+  Target average memory utilization, represented as a percentage of requested memory. To disable scaling based on memory, set to an empty string.
 * `server.autoscaling.behavior` - object, default: `{}`  
 
   Configuration for scaling up and down.

--- a/charts/trino/templates/autoscaler.yaml
+++ b/charts/trino/templates/autoscaler.yaml
@@ -14,12 +14,22 @@ spec:
     kind: Deployment
     name: {{ template "trino.worker" . }}
   metrics:
+  {{- if .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.server.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
   {{ if .Values.server.autoscaling.behavior -}}
   behavior:
     {{- toYaml .Values.server.autoscaling.behavior | nindent 4 }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -85,7 +85,10 @@ server:
   autoscaling:
     enabled: false
     maxReplicas: 5
+    # -- Target average CPU utilization, represented as a percentage of requested CPU. To disable scaling based on CPU, set to an empty string.
     targetCPUUtilizationPercentage: 50
+    # -- Target average memory utilization, represented as a percentage of requested memory. To disable scaling based on memory, set to an empty string.
+    targetMemoryUtilizationPercentage: 80
     behavior: {}
     # server.autoscaling.behavior -- Configuration for scaling up and down.
     # @raw

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 server:
+  workers: 2
   config:
     https:
       enabled: true
@@ -12,6 +13,8 @@ server:
   coordinatorExtraConfig: |
     query.client.timeout=5m
     query.execution-policy=phased
+  autoscaling:
+    enabled: true
 
 additionalConfigProperties:
   - internal-communication.shared-secret=random-value-999


### PR DESCRIPTION
Hello!

This PR aims to enable the possibility of using memory resource in the HPA. I noticed that there is an open PR (https://github.com/trinodb/charts/pull/219) regarding this, but it has been inactive for a month, and this is a feature I really need.

A new variable has been created in the values (targetMemoryUtilizationPercentage), with a default value of 80. In the HPA manifest, I added a conditional check to see if a value is set for this variable, allowing the assignment of an empty value ("") to one of them to not use the metric. I also included this condition for targetCPUUtilizationPercentage (since someone might not want to scale based on CPU).