### PR TITLE
Allow setting nodePort in .Values.coordinator.additionalExposedPorts

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -421,6 +421,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
      servicePort: 8443
      name: https
      port: 8443
+     nodePort: 30443
      protocol: TCP
   ```
 * `coordinator.resources` - object, default: `{}`  

--- a/charts/trino/templates/service-coordinator.yaml
+++ b/charts/trino/templates/service-coordinator.yaml
@@ -24,12 +24,18 @@ spec:
       targetPort: jmx-exporter
       protocol: TCP
       name: jmx-exporter
+      {{- if $coordinatorJmx.exporter.nodePort }}
+      nodePort: {{ $coordinatorJmx.exporter.nodePort }}
+      {{- end }}
     {{- end }}
     {{- range $key, $value := .Values.coordinator.additionalExposedPorts }}
     - port: {{ $value.servicePort }}
       name: {{ $value.name }}
       targetPort: {{ $value.port }}
       protocol: {{ $value.protocol }}
+      {{- if $value.nodePort }}
+      nodePort: {{ $value.nodePort }}
+      {{- end }}
     {{- end }}
   selector:
     {{- include "trino.selectorLabels" . | nindent 4 }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -478,6 +478,7 @@ coordinator:
   #    servicePort: 8443
   #    name: https
   #    port: 8443
+  #    nodePort: 30443
   #    protocol: TCP
   # ```
 

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -73,6 +73,7 @@ coordinator:
       servicePort: 8443
       name: https
       port: 8443
+      nodePort: 30443
       protocol: TCP
 
 worker:


### PR DESCRIPTION
When deploying on Kubernetes I was faced with additionalExposedPorts nodePorts that kept changing after each deploy due to the nodePort not being specified in the Helm chart, as explained here https://trinodb.slack.com/archives/CGB0QHWSW/p1727943085442609?thread_ts=1722396654.245879&cid=CGB0QHWSW

The purpose of this pull request is to allow something like:

```
  additionalExposedPorts:
    https:
      servicePort: 8443
      name: https
      port: 8443
      nodePort: 30443
      protocol: TCP
```

not only for https but also for other services. 