### PR TITLE
Add deployment spec properties to coordinator and worker

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -403,6 +403,15 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
      secretName: sample-secret
      path: /secrets/sample.json
   ```
+* `coordinator.deployment.progressDeadlineSeconds` - int, default: `600`  
+
+  The maximum time in seconds for a deployment to make progress before it is considered failed. The deployment controller continues to process failed deployments and a condition with a ProgressDeadlineExceeded reason is surfaced in the deployment status.
+* `coordinator.deployment.revisionHistoryLimit` - int, default: `10`  
+
+  The number of old ReplicaSets to retain to allow rollback.
+* `coordinator.deployment.strategy` - object, default: `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}`  
+
+  The deployment strategy to use to replace existing pods with new ones.
 * `coordinator.jvm.maxHeapSize` - string, default: `"8G"`
 * `coordinator.jvm.gcMethod.type` - string, default: `"UseG1GC"`
 * `coordinator.jvm.gcMethod.g1.heapRegionSize` - string, default: `"32M"`
@@ -510,6 +519,15 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
      secretName: sample-secret
      path: /secrets/sample.json
   ```
+* `worker.deployment.progressDeadlineSeconds` - int, default: `600`  
+
+  The maximum time in seconds for a deployment to make progress before it is considered failed. The deployment controller continues to process failed deployments and a condition with a ProgressDeadlineExceeded reason is surfaced in the deployment status.
+* `worker.deployment.revisionHistoryLimit` - int, default: `10`  
+
+  The number of old ReplicaSets to retain to allow rollback.
+* `worker.deployment.strategy` - object, default: `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}`  
+
+  The deployment strategy to use to replace existing pods with new ones.
 * `worker.jvm.maxHeapSize` - string, default: `"8G"`
 * `worker.jvm.gcMethod.type` - string, default: `"UseG1GC"`
 * `worker.jvm.gcMethod.g1.heapRegionSize` - string, default: `"32M"`

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -12,6 +12,10 @@ metadata:
     {{- tpl (toYaml .Values.coordinator.labels) . | nindent 4 }}
     {{- end }}
 spec:
+  progressDeadlineSeconds: {{ .Values.coordinator.deployment.progressDeadlineSeconds }}
+  revisionHistoryLimit: {{ .Values.coordinator.deployment.revisionHistoryLimit }}
+  strategy:
+    {{- toYaml .Values.coordinator.deployment.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "trino.selectorLabels" . | nindent 6 }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -13,6 +13,10 @@ metadata:
     {{- tpl (toYaml .Values.worker.labels) . | nindent 4 }}
     {{- end }}
 spec:
+  progressDeadlineSeconds: {{ .Values.worker.deployment.progressDeadlineSeconds }}
+  revisionHistoryLimit: {{ .Values.worker.deployment.revisionHistoryLimit }}
+  strategy:
+    {{- toYaml .Values.worker.deployment.strategy | nindent 4 }}
   {{- if not .Values.server.autoscaling.enabled }}
   replicas: {{ .Values.server.workers }}
   {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -461,6 +461,23 @@ secretMounts: []
 # ```
 
 coordinator:
+  deployment:
+    progressDeadlineSeconds: 600
+    # coordinator.deployment.progressDeadlineSeconds -- The maximum time in seconds for a deployment to make progress before it
+    # is considered failed. The deployment controller continues to
+    # process failed deployments and a condition with a ProgressDeadlineExceeded
+    # reason is surfaced in the deployment status.
+
+    revisionHistoryLimit: 10
+    # coordinator.deployment.revisionHistoryLimit -- The number of old ReplicaSets to retain to allow rollback.
+
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+    # coordinator.deployment.strategy -- The deployment strategy to use to replace existing pods with new ones.
+
   jvm:
     maxHeapSize: "8G"
     gcMethod:
@@ -604,6 +621,23 @@ coordinator:
   # ```
 
 worker:
+  deployment:
+    progressDeadlineSeconds: 600
+    # worker.deployment.progressDeadlineSeconds -- The maximum time in seconds for a deployment to make progress before it
+    # is considered failed. The deployment controller continues to
+    # process failed deployments and a condition with a ProgressDeadlineExceeded
+    # reason is surfaced in the deployment status.
+
+    revisionHistoryLimit: 10
+    # worker.deployment.revisionHistoryLimit -- The number of old ReplicaSets to retain to allow rollback.
+
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+    # worker.deployment.strategy -- The deployment strategy to use to replace existing pods with new ones.
+
   jvm:
     maxHeapSize: "8G"
     gcMethod:

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -45,6 +45,15 @@ secretMounts:
     path: /etc/trino/certificates
 
 coordinator:
+  deployment:
+    progressDeadlineSeconds: 500
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 50%
+
   jvm:
     maxHeapSize: "8G"
     gcMethod:
@@ -74,6 +83,15 @@ coordinator:
       protocol: TCP
 
 worker:
+  deployment:
+    progressDeadlineSeconds: 500
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 50%
+
   jvm:
     maxHeapSize: "8G"
     gcMethod:


### PR DESCRIPTION
Reference PR: #236 

Adding deployment spec values for `coordinator` deployment and `worker` deployment:
```
 - progressDeadlineSeconds
 - revisionHistoryLimit
 - strategy
```
This is needed for us in case of an update of Trino Cluster that requires the deployment to bring pods up and down.