### PR TITLE
Fix the complete_values test

### DIFF
--- a/test-values.yaml
+++ b/test-values.yaml
@@ -80,7 +80,6 @@ coordinator:
       servicePort: 8443
       name: https
       port: 8443
-      nodePort: 30443
       protocol: TCP
 
 worker:


### PR DESCRIPTION
Revert adding a nodePort to additionalExposedPorts, since it requires changing the service type to NodePort, and that cannot be tested together with network policies.

Follow-up to #241