### PR TITLE
Release both trino and trino-gateway charts

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -104,6 +104,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          repository: trinodb/trino-gateway
+          path: gateway
+          filter: tree:0
+          sparse-checkout: helm/trino-gateway
+      - run: |
+          mv gateway/helm/trino-gateway charts/gateway
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
The gateway chart doesn't have any README yet, so don't try to publish it, only add the chart to the index.