### PR TITLE
Add support for Database resource group manager

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -175,9 +175,23 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
   ```
 * `resourceGroups` - object, default: `{}`  
 
-  Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
-  Example:
+  [Resource groups control](https://trino.io/docs/current/admin/resource-groups.html)
+  Set the type property to either:
+  * `configmap`, and provide the Resource groups file contents in `resourceGroupsConfig`,
+  * `properties`, and provide configuration properties in `properties`.
+  Properties example:
   ```yaml
+   type: properties
+   properties: |
+     resource-groups.configuration-manager=db
+     resource-groups.config-db-url=jdbc:postgresql://trino-postgresql.postgresql.svc.cluster.local:3306/resource_groups
+     resource-groups.config-db-user=username
+     resource-groups.config-db-password=password
+  ```
+  Config map example:
+  ```yaml
+   type: configmap
+   # Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
    resourceGroupsConfig: |-
        {
          "rootGroups": [

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -105,9 +105,20 @@ data:
 {{- end }}
 
 {{- if .Values.resourceGroups }}
+  {{- if eq .Values.resourceGroups.type "configmap" }}
   resource-groups.properties: |
     resource-groups.configuration-manager=file
     resource-groups.config-file={{ .Values.server.config.path }}/resource-groups/resource-groups.json
+  {{- else if eq .Values.resourceGroups.type "properties" }}
+  resource-groups.properties: |
+    {{- if .Values.resourceGroups.properties }}
+    {{- .Values.resourceGroups.properties | nindent 4 }}
+    {{- else}}
+    {{- fail "resourceGroups.properties is required when resourceGroups.type is 'properties'." }}
+    {{- end }}
+  {{- else}}
+  {{- fail "Invalid resourceGroups.type value. It must be either 'configmap' or 'properties'." }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.server.exchangeManager }}
@@ -151,7 +162,7 @@ data:
   {{ $fileName }}: |
     {{- tpl $fileContent $ | nindent 4 }}
 {{- end }}
-{{- if .Values.resourceGroups }}
+{{- if eq .Values.resourceGroups.type "configmap" }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -69,7 +69,7 @@ spec:
           configMap:
             name: {{ template "trino.fullname" . }}-access-control-volume-coordinator
         {{- end }}
-        {{- if .Values.resourceGroups }}
+        {{- if eq .Values.resourceGroups.type "configmap" }}
         - name: resource-groups-volume
           configMap:
             name: {{ template "trino.fullname" . }}-resource-groups-volume-coordinator
@@ -150,7 +150,7 @@ spec:
             - mountPath: {{ .Values.server.config.path }}/access-control
               name: access-control-volume
             {{- end }}
-            {{- if .Values.resourceGroups }}
+            {{- if eq .Values.resourceGroups.type "configmap" }}
             - mountPath: {{ .Values.server.config.path }}/resource-groups
               name: resource-groups-volume
             {{- end }}

--- a/charts/trino/templates/tests/test-connection.yaml
+++ b/charts/trino/templates/tests/test-connection.yaml
@@ -9,6 +9,23 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  {{- if eq .Values.resourceGroups.type "properties" }}
+  initContainers:
+    - name: postgresql-client
+      image: bitnami/postgresql:17.1.0
+      command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Inserting resource groups data";
+          PGUSER=trino PGPASSWORD=pass0000 psql -h trino-resource-groups-db-postgresql.postgresql.svc.cluster.local resource_groups <<SQL
+          -- create a root group 'admin' with NULL parent
+          INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_policy, environment)
+          VALUES ('admin', '100%', 50, 100, 'query_priority', 'production');
+          -- use ID of 'admin' resource group for selector
+          INSERT INTO selectors (resource_group_id, user_regex, priority) VALUES ((SELECT resource_group_id FROM resource_groups WHERE name = 'admin'), 'admin', 6);
+          SQL
+  {{- end }}
   containers:
     - name: cli
       image: {{ include "trino.image" . }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -183,10 +183,24 @@ accessControl: {}
 # ```
 
 resourceGroups: {}
-# resourceGroups -- Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
+# resourceGroups -- [Resource groups control](https://trino.io/docs/current/admin/resource-groups.html)
 # @raw
-# Example:
+# Set the type property to either:
+# * `configmap`, and provide the Resource groups file contents in `resourceGroupsConfig`,
+# * `properties`, and provide configuration properties in `properties`.
+# Properties example:
 # ```yaml
+#  type: properties
+#  properties: |
+#    resource-groups.configuration-manager=db
+#    resource-groups.config-db-url=jdbc:postgresql://trino-postgresql.postgresql.svc.cluster.local:3306/resource_groups
+#    resource-groups.config-db-user=username
+#    resource-groups.config-db-password=password
+# ```
+# Config map example:
+# ```yaml
+#  type: configmap
+#  # Resource groups file is mounted to /etc/trino/resource-groups/resource-groups.json
 #  resourceGroupsConfig: |-
 #      {
 #        "rootGroups": [

--- a/test-resource-groups-properties-values.yaml
+++ b/test-resource-groups-properties-values.yaml
@@ -1,0 +1,15 @@
+# Resource Groups 'properties' values to test.
+# This is a YAML-formatted file.
+
+server:
+  log:
+    trino:
+      level: INFO
+
+resourceGroups:
+  type: properties
+  properties: |
+    resource-groups.configuration-manager=db
+    resource-groups.config-db-url=jdbc:postgresql://trino-resource-groups-db-postgresql.postgresql.svc.cluster.local:5432/resource_groups
+    resource-groups.config-db-user=trino
+    resource-groups.config-db-password=pass0000

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -172,6 +172,66 @@ accessControl:
         ]
       }
 
+resourceGroups:
+  type: configmap
+  resourceGroupsConfig: |-
+    {
+      "rootGroups": [
+        {
+          "name": "global",
+          "softMemoryLimit": "80%",
+          "hardConcurrencyLimit": 100,
+          "maxQueued": 100,
+          "schedulingPolicy": "fair",
+          "jmxExport": true,
+          "subGroups": [
+            {
+              "name": "admin",
+              "softMemoryLimit": "30%",
+              "hardConcurrencyLimit": 20,
+              "maxQueued": 10
+            },
+            {
+              "name": "finance_human_resources",
+              "softMemoryLimit": "20%",
+              "hardConcurrencyLimit": 15,
+              "maxQueued": 10
+            },
+            {
+              "name": "general",
+              "softMemoryLimit": "30%",
+              "hardConcurrencyLimit": 20,
+              "maxQueued": 10
+            },
+            {
+              "name": "readonly",
+              "softMemoryLimit": "10%",
+              "hardConcurrencyLimit": 5,
+              "maxQueued": 5
+            }
+          ]
+        }
+      ],
+      "selectors": [
+        {
+          "user": "admin",
+          "group": "global.admin"
+        },
+        {
+          "group": "finance|human_resources",
+          "group": "global.finance_human_resources"
+        },
+        {
+          "user": "alice",
+          "group": "global.readonly"
+        },
+        {
+          "group": "global.general"
+        }
+      ]
+    }
+
+
 jmx:
   enabled: true
   registryPort: 9080


### PR DESCRIPTION
This PR enhances the Trino Helm chart by adding support for the Database resource group manager. Previously, only file-based configurations using ConfigMap were supported.

Additionally, the implementation is closely modeled after the existing accessControl pattern in the chart, ensuring consistency in the configuration approach.

### Limitations

In the process of implementing this feature, we considered deploying the MySQL container in the same namespace as Trino to streamline configuration. However, the MySQL service endpoint URL includes the namespace, making it challenging to set a dynamic reference. To maintain stability and avoid complex configurations, we fixed the MySQL namespace as mysql, ultimately deciding against further attempts at a flexible namespace solution for this PR.