### PR TITLE
added hostAliases support for coordinator and worker deployment

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -477,6 +477,17 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `coordinator.nodeSelector` - object, default: `{}`
 * `coordinator.tolerations` - list, default: `[]`
 * `coordinator.affinity` - object, default: `{}`
+* `coordinator.hostAliases` - list, default: `[]`
+  For databases with self signed certificate and without valid domain names, sometimes you need to set databace host in /etc/hosts file.
+  [Adding entries to Pod /etc/hosts with HostAliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods)
+  Example:
+  ```yaml
+   - hostnames:
+     - name-1
+     - name-2
+     - name-3
+     ip: 1.1.1.1
+  ```
 * `coordinator.additionalConfigFiles` - object, default: `{}`  
 
   Additional config files placed in the default configuration directory. Supports templating the files' contents with `tpl`.
@@ -602,6 +613,17 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `worker.nodeSelector` - object, default: `{}`
 * `worker.tolerations` - list, default: `[]`
 * `worker.affinity` - object, default: `{}`
+* `coordinator.hostAliases` - list, default: `[]`
+  For databases with self signed certificate and without valid domain names, sometimes you need to set databace host in /etc/hosts file.
+  [Adding entries to Pod /etc/hosts with HostAliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods)
+  Example:
+  ```yaml
+   - hostnames:
+     - name-1
+     - name-2
+     - name-3
+     ip: 1.1.1.1
+  ```
 * `worker.additionalConfigFiles` - object, default: `{}`  
 
   Additional config files placed in the default configuration directory. Supports templating the files' contents with `tpl`.

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -122,6 +122,10 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
+      {{- if .Values.coordinator.hostAliases }}
+      hostAliases:
+      {{- toYaml .Values.coordinator.hostAliases | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.coordinator.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}-coordinator

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -106,6 +106,10 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
+      {{- if .Values.worker.hostAliases }}
+      hostAliases:
+      {{- toYaml .Values.worker.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if and .Values.worker.gracefulShutdown.enabled (gt (mulf 2.0 .Values.worker.gracefulShutdown.gracePeriodSeconds) .Values.worker.terminationGracePeriodSeconds) }}
       {{- fail "The user must set the `worker.terminationGracePeriodSeconds` to a value of at least two times the configured `gracePeriodSeconds`." }}
       {{- else }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -568,6 +568,18 @@ coordinator:
 
   affinity: {}
 
+  hostAliases:
+  # coordinator.hostAliases -- [Adding entries to Pod /etc/hosts with HostAliases] (https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/).
+  # @raw
+  # Example:
+  # ```yaml
+  #  - hostnames:
+  #    - name-1
+  #    - name-2
+  #    - name-3
+  #    ip: 1.1.1.1
+  # ```
+
   additionalConfigFiles: {}
   # coordinator.additionalConfigFiles -- Additional config files placed in the default configuration directory.
   # Supports templating the files' contents with `tpl`.
@@ -747,6 +759,18 @@ worker:
   tolerations: []
 
   affinity: {}
+
+  hostAliases: []
+  # worker.hostAliases -- [Adding entries to Pod /etc/hosts with HostAliases] (https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/).
+  # @raw
+  # Example:
+  # ```yaml
+  #  - hostnames:
+  #    - name-1
+  #    - name-2
+  #    - name-3
+  #    ip: 1.1.1.1
+  # ```
 
   additionalConfigFiles: {}
   # worker.additionalConfigFiles -- Additional config files placed in the default configuration directory.


### PR DESCRIPTION
Adding hostAliases template and values for coordinator deployment and worker deployment

This is useful for connect to databases with selfsigned certificate and invalid domain name