### PR TITLE
Add service annotations support to Trino Gateway Chart

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -55,6 +55,7 @@ A Helm chart for Trino Gateway
   Startup command for Trino Gateway process. Add additional Java options and other modifications as desired.
 * `service.type` - string, default: `"ClusterIP"`
 * `service.port` - int, default: `8080`
+* `service.annotations` - object, default: `{}`
 * `ingress.enabled` - bool, default: `false`
 * `ingress.className` - string, default: `""`
 * `ingress.annotations` - object, default: `{}`

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "trino-gateway.fullname" . }}
   labels:
     {{- include "trino-gateway.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -71,6 +71,7 @@ command:
 service:
   type: ClusterIP
   port: 8080
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
- Introduced functionality to allow specifying annotations for Trino Gateway services.
- Ensures compatibility with Kubernetes custom annotations for enhanced service configurations.
- Updated relevant templates and documentation to reflect the changes.

This feature enables users to add annotations for service monitoring, ingress, or other Kubernetes integrations.