### PR TITLE
Add envFrom and remove lookup

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -28,15 +28,15 @@ A Helm chart for Trino Gateway
   imagePullSecrets:
     - name: registry-credentials
   ```
-* `dataStoreSecret` - object, default: `{"key":"","name":""}`  
+* `envFrom` - list, default: `[]`  
 
-  Provide configuration for the Trino Gateway `dataStore` in `dataStoreSecret`. This node can be left undefined if `dataStore` is defined under the config node. For production deployments sensitive values should be stored in a Secret
-* `backendStateSecret` - object, default: `{"key":"","name":""}`  
-
-  Provide configuration for the Trino Gateway `backendState` in `backendStateSecret`. This should be used with health check configurations that require backend credentials. This node can be left undefined if `dataStore` is defined under the config node.
-* `authenticationSecret` - object, default: `{"key":"","name":""}`  
-
-  Provide configuration for the Trino Gateway authentication configuration in `authenticationSecret`. This node can be left undefined if `dataStore` is defined under the config node.
+  A list of secrets and configmaps to mount into the init container as environment variables.
+  Example:
+  ```yaml
+  envFrom:
+    - secretRef:
+        name: password-secret
+  ```
 * `config.serverConfig."node.environment"` - string, default: `"test"`
 * `config.serverConfig."http-server.http.port"` - int, default: `8080`
 * `config.dataStore.jdbcUrl` - string, default: `"jdbc:postgresql://localhost:5432/gateway"`  

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -14,12 +14,6 @@ spec:
   template:
     metadata:
       annotations:
-        # Include the version of trino-gateway-configuration as an input to the
-        # deployment checksum. This causes pods to restart on helm update
-        # whether the chart `config` is updated or if one of the configuration
-        # secrets is updated. Helm template must be run with the
-        # --dry-run=server option to prevent a nil pointer.
-        checksum/config: {{ (coalesce (lookup "v1" "Secret" .Release.Namespace "trino-gateway-configuration").metadata (dict "resourceVersion" "0")).resourceVersion | sha256sum}}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -44,6 +38,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             {{- toYaml .Values.command | nindent 12}}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12}}
           ports:
             - name: request
               containerPort: {{ index .Values "config" "serverConfig" "http-server.http.port" }}

--- a/charts/gateway/templates/secrets.yaml
+++ b/charts/gateway/templates/secrets.yaml
@@ -1,22 +1,7 @@
-{{ $dataStoreDict :=  dict}}
-{{ if .Values.dataStoreSecret.name }}
-{{ $dataStoreDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.dataStoreSecret.name).data .Values.dataStoreSecret.key) | b64dec | fromYaml }}
-{{ end }}
-{{ $backendStateDict := dict }}
-{{ if .Values.backendStateSecret.name }}
-{{ $backendStateDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.backendStateSecret.name).data .Values.backendStateSecret.key) | b64dec | fromYaml }}
-{{ end }}
-{{ $authenticationDict := dict }}
-{{ if .Values.authenticationSecret.name }}
-# {{.Values.authenticationSecret.name }} #
-# {{ index (lookup "v1" "Secret" .Release.Namespace .Values.authenticationSecret.name).data .Values.authenticationSecret.key }} #
-{{ $authenticationDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.authenticationSecret.name).data .Values.authenticationSecret.key) | b64dec | fromYaml  }}
-{{ end }}
-
 apiVersion: v1
 kind: Secret
 metadata:
     name: trino-gateway-configuration
 type: "Opaque"
 data:
-    config.yaml: "{{toYaml (merge .Values.config $authenticationDict $dataStoreDict $backendStateDict ) | b64enc}}"
+    config.yaml: "{{toYaml .Values.config | b64enc}}"

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -20,25 +20,15 @@ image:
 # ```
 imagePullSecrets: []
 
-# -- Provide configuration for the Trino Gateway `dataStore` in `dataStoreSecret`. This node can
-# be left undefined if `dataStore` is defined under the config node. For production deployments
-# sensitive values should be stored in a Secret
-dataStoreSecret:
-  name: ""
-  key: ""
-
-# -- Provide configuration for the Trino Gateway `backendState` in `backendStateSecret`. This should
-# be used with health check configurations that require backend credentials. This node can
-# be left undefined if `dataStore` is defined under the config node.
-backendStateSecret:
-  name: ""
-  key: ""
-
-# -- Provide configuration for the Trino Gateway authentication configuration in `authenticationSecret`.
-# This node can be left undefined if `dataStore` is defined under the config node.
-authenticationSecret:
-  name: ""
-  key: ""
+# -- A list of secrets and configmaps to mount into the init container as environment variables.
+# @raw
+# Example:
+# ```yaml
+# envFrom:
+#   - secretRef:
+#       name: password-secret
+# ```
+envFrom: []
 
 config:
   serverConfig:

--- a/tests/gateway/test-values-with-env.yaml
+++ b/tests/gateway/test-values-with-env.yaml
@@ -1,0 +1,37 @@
+replicaCount: 1
+
+image:
+  # -- Repository location of the Trino Gateway image, typically `organization/imagename`
+  repository: "trinodb/trino-gateway"
+  pullPolicy: IfNotPresent
+
+config:
+  serverConfig:
+    node.environment: test
+    http-server.http.port: 8080
+  dataStore:
+    # The connection details for the backend database for Trino Gateway and Trino query history
+    jdbcUrl: jdbc:postgresql://gateway-backend-db-postgresql.postgres-gateway.svc.cluster.local:5432/gateway
+    user: "${ENV:PG_USER}"
+    password: "${ENV:PG_PASSWORD}"
+    driver: org.postgresql.Driver
+  clusterStatsConfiguration:
+    monitorType: INFO_API
+  modules:
+    - io.trino.gateway.ha.module.HaGatewayProviderModule
+    - io.trino.gateway.ha.module.ClusterStateListenerModule
+    - io.trino.gateway.ha.module.ClusterStatsMonitorModule
+  managedApps:
+    - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
+
+envFrom:
+  - secretRef:
+      name: db-credentials
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi

--- a/tests/gateway/test.sh
+++ b/tests/gateway/test.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 
 declare -A testCases=(
     [complete_values]="--values test-values.yaml"
+    [env_from]="--values test-values-with-env.yaml"
 )
 
 declare -A testCaseCharts=(
     [complete_values]="../../charts/gateway"
+    [env_from]="../../charts/gateway"
 )
 
 function join_by {
@@ -28,7 +30,7 @@ CT_ARGS=(
     --helm-extra-args="--timeout 2m"
 )
 CLEANUP_NAMESPACE=true
-TEST_NAMES=(complete_values)
+TEST_NAMES=(complete_values env_from)
 
 usage() {
     cat <<EOF 1>&2
@@ -86,6 +88,8 @@ helm upgrade --install ${DB_INSTALLATION_NAME} oci://registry-1.docker.io/bitnam
     --set auth.database=gateway \
     --set primary.persistence.enabled=false
 kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgresql --timeout=300s -n "$DB_NAMESPACE"
+
+kubectl --namespace "$NAMESPACE" create secret generic db-credentials --from-literal=PG_USER='gateway' --from-literal=PG_PASSWORD='pass0000'
 
 result=0
 for test_name in "${TEST_NAMES[@]}"; do


### PR DESCRIPTION
Add `envFrom` to allow providing environment variables from Secrets, and remove usage of the Helm `lookup` function for merging Secrets into the configuration. 

This removes the custom checksum calculation as well. The checksum had included the optional configuration secrets, causing pod restarts whether configuration was updated through the chart or through a secret. Since this required retrieving Secrets from the target cluster through the Helm `lookup` function, it caused the chart to be incompatible with release pipelines in which a manifest is generated in an environment that does not have access to the target cluster. 