### PR TITLE
Add service monitor API version override

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -783,6 +783,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `serviceMonitor.enabled` - bool, default: `false`  
 
   Set to true to create resources for the [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator).
+* `serviceMonitor.apiVersion` - string, default: `"monitoring.coreos.com/v1"`
 * `serviceMonitor.labels` - object, default: `{"prometheus":"kube-prometheus"}`  
 
   Labels for serviceMonitor, so that Prometheus can select it

--- a/charts/trino/templates/servicemonitor-coordinator.yaml
+++ b/charts/trino/templates/servicemonitor-coordinator.yaml
@@ -1,6 +1,6 @@
 {{- $coordinatorServiceMonitor := merge .Values.serviceMonitor.coordinator (omit .Values.serviceMonitor "coordinator" "worker") -}}
 {{- if $coordinatorServiceMonitor.enabled -}}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ $coordinatorServiceMonitor.apiVersion }}
 kind: ServiceMonitor
 metadata:
   name: {{ template "trino.fullname" . }}

--- a/charts/trino/templates/servicemonitor-worker.yaml
+++ b/charts/trino/templates/servicemonitor-worker.yaml
@@ -1,6 +1,6 @@
 {{- $workerServiceMonitor := merge .Values.serviceMonitor.worker (omit .Values.serviceMonitor "coordinator" "worker") -}}
 {{- if $workerServiceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ $workerServiceMonitor.apiVersion }}
 kind: ServiceMonitor
 metadata:
   name: {{ template "trino.fullname" . }}-worker

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -948,6 +948,8 @@ serviceMonitor:
   # serviceMonitor.enabled -- Set to true to create resources for the
   # [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator).
   enabled: false
+
+  apiVersion: monitoring.coreos.com/v1
   # serviceMonitor.labels -- Labels for serviceMonitor, so that Prometheus can select it
   labels:
     prometheus: kube-prometheus


### PR DESCRIPTION
This feature enables users to override the Service Monitor API version if they are using Azure managed prometheus which uses `azmonitoring.coreos.com/v1` instead of the default `monitoring.coreos.com/v1`.