### PR TITLE
Allow list syntax for exchangeManager baseDir targets

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -124,7 +124,7 @@ data:
 {{- if .Values.server.exchangeManager }}
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}
-    exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
+    exchange.base-directories={{ join "," .Values.server.exchangeManager.baseDir }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
     {{ $configValue }}
   {{- end }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -81,7 +81,7 @@ data:
 {{- if .Values.server.exchangeManager }}
   exchange-manager.properties: |
     exchange-manager.name={{ .Values.server.exchangeManager.name }}
-    exchange.base-directories={{ .Values.server.exchangeManager.baseDir }}
+    exchange.base-directories={{ join "," .Values.server.exchangeManager.baseDir }}
   {{- range $configValue := .Values.additionalExchangeManagerProperties }}
     {{ $configValue }}
   {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -62,16 +62,17 @@ server:
   exchangeManager: {}
   # server.exchangeManager -- Mandatory [exchange manager
   # configuration](https://trino.io/docs/current/admin/fault-tolerant-execution.html#id1).
-  # Used to set the name and location(s) of the spooling storage destination. To enable fault-tolerant execution,
-  # set the `retry-policy` property in `additionalConfigProperties`. Additional exchange manager configurations can be
-  # added to `additionalExchangeManagerProperties`.
+  # Used to set the name and location(s) of spooling data storage. For multiple destinations use a list or a comma separated URI locations. 
+  # To enable fault-tolerant execution, set the `retry-policy` property in `additionalConfigProperties`. 
+  # Additional exchange manager configurations can be added to `additionalExchangeManagerProperties`.
   # @raw
   # Example:
   # ```yaml
   # server:
   #   exchangeManager:
   #     name: "filesystem"
-  #     baseDir: "/tmp/trino-local-file-system-exchange-manager"
+  #     baseDir:
+  #       - "/tmp/trino-local-file-system-exchange-manager"
   # additionalConfigProperties:
   #   - retry-policy=TASK
   # additionalExchangeManagerProperties:


### PR DESCRIPTION
This change will allow using list syntax of exchangeManager base-directories which is more common and understandable with Helm charts.

Trino allows specifying multiple spooling targets for exchageManager separated by comma when using main cloud providers or any S3 compatible protocol (example: s3://bucket1,s3://bucket2,s3://bucket3). With current trinodb/charts we have to specify them within values as a single line for baseDir:

```
server:
  exchangeManager:
    name: "filesystem"
    baseDir: "s3://exchange-spooling-bucket-1,s3://exchange-spooling-bucket-2"
```

Which translates to:

```
  exchange-manager.properties: |
    exchange-manager.name=filesystem
    exchange.base-directories=s3://exchange-spooling-bucket-1,s3://exchange-spooling-bucket-2
```

This change allows a more clean listing within values:

```
server:
  exchangeManager:
    name: "filesystem"
    baseDir:
    - "s3://exchange-spooling-bucket-1"
    - "s3://exchange-spooling-bucket-2"
```

Which translates to the same:

```
  exchange-manager.properties: |
    exchange-manager.name=filesystem
    exchange.base-directories=s3://exchange-spooling-bucket-1,s3://exchange-spooling-bucket-2
```

It will not break any existing listings as stating them the same way as before in a single line will result in exchange.base-directories within a single line. 
Documentation for setting up fault tolerant execution: https://trino.io/docs/current/admin/fault-tolerant-execution.html