### PR TITLE
Support subPath in secretMounts and configMounts

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -411,6 +411,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    - name: sample-config-mount
      configMap: sample-config-map
      path: /config-map/sample.json
+     subPath: sample.json
   ```
 * `secretMounts` - list, default: `[]`  
 
@@ -420,6 +421,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    - name: sample-secret
      secretName: sample-secret
      path: /secrets/sample.json
+     subPath: sample.json
   ```
 * `coordinator.deployment.annotations` - object, default: `{}`
 * `coordinator.deployment.progressDeadlineSeconds` - int, default: `600`  
@@ -529,6 +531,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    - name: sample-config-mount
      configMap: sample-config-mount
      path: /config-mount/sample.json
+     subPath: sample.json
   ```
 * `coordinator.secretMounts` - list, default: `[]`  
 
@@ -538,6 +541,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    - name: sample-secret
      secretName: sample-secret
      path: /secrets/sample.json
+     subPath: sample.json
   ```
 * `worker.deployment.annotations` - object, default: `{}`
 * `worker.deployment.progressDeadlineSeconds` - int, default: `600`  
@@ -657,6 +661,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
   - name: sample-config-mount
     configMap: sample-config-mount
     path: /config-mount/sample.json
+    subPath: sample.json
   ```
 * `worker.secretMounts` - list, default: `[]`  
 
@@ -666,6 +671,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    - name: sample-secret
      secretName: sample-secret
      path: /secrets/sample.json
+     subPath: sample.json
   ```
 * `kafka.mountPath` - string, default: `"/etc/trino/schemas"`
 * `kafka.tableDescriptions` - object, default: `{}`  

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -157,18 +157,30 @@ spec:
             {{- range .Values.configMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- range .Values.coordinator.configMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- range .Values.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- range .Values.coordinator.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- if or .Values.auth.passwordAuth .Values.auth.passwordAuthSecret }}
             - mountPath: {{ .Values.server.config.path }}/auth/password

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -139,18 +139,30 @@ spec:
             {{- range .Values.configMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- range .Values.worker.configMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- range .Values.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- range .Values.worker.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
             {{- with .Values.worker.additionalVolumeMounts }}
             {{- . | toYaml | nindent 12 }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -465,6 +465,7 @@ configMounts: []
 #  - name: sample-config-mount
 #    configMap: sample-config-map
 #    path: /config-map/sample.json
+#    subPath: sample.json
 # ```
 
 secretMounts: []
@@ -476,6 +477,7 @@ secretMounts: []
 #  - name: sample-secret
 #    secretName: sample-secret
 #    path: /secrets/sample.json
+#    subPath: sample.json
 # ```
 
 coordinator:
@@ -627,6 +629,7 @@ coordinator:
   #  - name: sample-config-mount
   #    configMap: sample-config-mount
   #    path: /config-mount/sample.json
+  #    subPath: sample.json
   # ```
 
   secretMounts: []
@@ -638,6 +641,7 @@ coordinator:
   #  - name: sample-secret
   #    secretName: sample-secret
   #    path: /secrets/sample.json
+  #    subPath: sample.json
   # ```
 
 worker:
@@ -810,6 +814,7 @@ worker:
   # - name: sample-config-mount
   #   configMap: sample-config-mount
   #   path: /config-mount/sample.json
+  #   subPath: sample.json
   # ```
 
   secretMounts: []
@@ -821,6 +826,7 @@ worker:
   #  - name: sample-secret
   #    secretName: sample-secret
   #    path: /secrets/sample.json
+  #    subPath: sample.json
   # ```
 
 kafka:


### PR DESCRIPTION
The chart currently lacks support for specifying the [`subPath`](https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath) field for `secretMounts` and `configMounts` values. 
As a result, the mounted volumes overwrite the entire target directory.