### PR TITLE
Template external secrets configs injection

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -98,25 +98,25 @@ spec:
         {{- range .Values.configMounts }}
         - name: {{ .name }}
           configMap:
-            name: {{ .configMap }}
+            name: {{ tpl .configMap $ }}
         {{- end }}
         {{- range .Values.coordinator.configMounts }}
         - name: {{ .name }}
           configMap:
-            name: {{ .configMap }}
+            name: {{ tpl .configMap $ }}
         {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
-            secretName: {{ .secretName }}
+            secretName: {{ tpl .secretName $ }}
         {{- end }}
         {{- range .Values.coordinator.secretMounts }}
         - name: {{ .name }}
           secret:
-            secretName: {{ .secretName }}
+            secretName: {{ tpl .secretName $ }}
         {{- end }}
         {{- with .Values.coordinator.additionalVolumes }}
-        {{- . | toYaml | nindent 8 }}
+        {{- tpl (. | toYaml) $ | nindent 8 }}
         {{- end }}
       {{- if .Values.initContainers.coordinator }}
       initContainers:
@@ -136,7 +136,7 @@ spec:
           env:
             {{- toYaml .Values.env | nindent 12 }}
           envFrom:
-            {{- toYaml .Values.envFrom | nindent 12 }}
+            {{- tpl (toYaml .Values.envFrom) . | nindent 12 }}
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -80,25 +80,25 @@ spec:
         {{- range .Values.configMounts }}
         - name: {{ .name }}
           configMap:
-            name: {{ .configMap }}
+            name: {{ tpl .configMap $ }}
         {{- end }}
         {{- range .Values.worker.configMounts }}
         - name: {{ .name }}
           configMap:
-            name: {{ .configMap }}
+            name: {{ tpl .configMap $ }}
         {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
           secret:
-            secretName: {{ .secretName }}
+            secretName: {{ tpl .secretName $ }}
         {{- end }}
         {{- range .Values.worker.secretMounts }}
         - name: {{ .name }}
           secret:
-            secretName: {{ .secretName }}
+            secretName: {{ tpl .secretName $ }}
         {{- end }}
         {{- with .Values.worker.additionalVolumes }}
-        {{- . | toYaml | nindent 8 }}
+        {{- tpl (. | toYaml) $ | nindent 8 }}
         {{- end }}
       {{- if .Values.initContainers.worker }}
       initContainers:
@@ -122,7 +122,7 @@ spec:
           env:
             {{- toYaml .Values.env | nindent 12 }}
           envFrom:
-            {{- toYaml .Values.envFrom | nindent 12 }}
+            {{- tpl (toYaml .Values.envFrom) . | nindent 12 }}
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume

--- a/charts/trino/templates/ingress.yaml
+++ b/charts/trino/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl .secretName $ }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/trino/templates/tests/test-connection.yaml
+++ b/charts/trino/templates/tests/test-connection.yaml
@@ -58,6 +58,6 @@ spec:
   volumes:
     - name: certificates
       secret:
-        secretName: certificates
+        secretName: {{ .Release.Namespace }}-certificates
     {{- end }}
   restartPolicy: Never

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -41,7 +41,7 @@ auth:
 
 secretMounts:
   - name: certificates
-    secretName: certificates
+    secretName: '{{ .Release.Namespace }}-certificates'
     path: /etc/trino/certificates
 
 coordinator:

--- a/tests/trino/test.sh
+++ b/tests/trino/test.sh
@@ -91,7 +91,7 @@ openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
     -keyout cert.key -out cert.crt
 
 kubectl create namespace "$NAMESPACE" --dry-run=client --output yaml | kubectl apply --filename -
-kubectl -n "$NAMESPACE" create secret tls certificates --cert=cert.crt --key=cert.key --dry-run=client --output yaml | kubectl apply --filename -
+kubectl -n "$NAMESPACE" create secret tls "$NAMESPACE"-certificates --cert=cert.crt --key=cert.key --dry-run=client --output yaml | kubectl apply --filename -
 cat <<YAML | kubectl -n "$NAMESPACE" apply -f-
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
The current chart implementation requires static secret and configmap names to be provided in various mount-related values (`envFrom`, `additionalVolumes`, `secretMounts`, etc.).

This creates a challenge when the Trino chart is deployed as part of a parent  chart, with multiple deployments in the same namespace.
Similar to the Trino chart (which uses `{{ template "trino.fullname" . }}-` for unique resource names), the parent chart resource names are often rendered according to release-specific values, so the static naming requirement for these mounts of resources external in the Trino chart creates a limitation in such scenarios.

[Similar PRs](https://github.com/trinodb/charts/pull/283) have been raised in the past, including [one I previously opened ](https://github.com/trinodb/charts/pull/217)and closed because the use case wasn’t sufficiently justified at the time. In this case, however, the justification is clear: the current implementation prevents deploying a parent chart multiple times in the same namespace when Trino is a subchart, which I believe is a common use case.

I’ve updated the tests to demonstrate that the templating works correctly for resource names. However, the coverage may not include all the `tpl` changes I’ve introduced. Please let me know if additional test updates or further modifications are needed.