### PR TITLE
Release Trino Gateway chart 1.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the name to get an output similar to the following:
 ```
 NAME               	CHART VERSION	APP VERSION	DESCRIPTION
 trino/trino        	1.37.0       	470        	Fast distributed SQL query engine for big data ...
-trino/trino-gateway	1.13.2       	13         	A Helm chart for Trino Gateway
+trino/trino-gateway	1.14.0       	14         	A Helm chart for Trino Gateway
 ```
 
 Use `helm search repo trino -l` for information about all available versions.

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trino-gateway
 description: A Helm chart for Trino Gateway
 type: application
-version: "1.13.2"
-appVersion: "13"
+version: "1.14.0"
+appVersion: "14"
 
 icon: https://trino.io/assets/images/logos/trino-gateway-small.png
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1,6 +1,6 @@
 # trino-gateway
 
-![Version: 1.13.2](https://img.shields.io/badge/Version-1.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 13](https://img.shields.io/badge/AppVersion-13-informational?style=flat-square)
+![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 14](https://img.shields.io/badge/AppVersion-14-informational?style=flat-square)
 
 A Helm chart for Trino Gateway
 


### PR DESCRIPTION
In preparation for the release managed at https://github.com/trinodb/trino-gateway/pull/589

Must cut Trino Gateway release and merge https://github.com/trinodb/charts/pull/296 before this PR is merged