### PR TITLE
Remove deprecated settings from gateway config

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -47,10 +47,6 @@ A Helm chart for Trino Gateway
 * `config.dataStore.password` - string, default: `"mysecretpassword"`
 * `config.dataStore.driver` - string, default: `"org.postgresql.Driver"`
 * `config.clusterStatsConfiguration.monitorType` - string, default: `"INFO_API"`
-* `config.modules[0]` - string, default: `"io.trino.gateway.ha.module.HaGatewayProviderModule"`
-* `config.modules[1]` - string, default: `"io.trino.gateway.ha.module.ClusterStateListenerModule"`
-* `config.modules[2]` - string, default: `"io.trino.gateway.ha.module.ClusterStatsMonitorModule"`
-* `config.managedApps[0]` - string, default: `"io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor"`
 * `command` - list, default: `["java","-XX:MinRAMPercentage=80.0","-XX:MaxRAMPercentage=80.0","-jar","/usr/lib/trino/gateway-ha-jar-with-dependencies.jar","/etc/gateway/config.yaml"]`  
 
   Startup command for Trino Gateway process. Add additional Java options and other modifications as desired.

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -43,12 +43,6 @@ config:
     driver: org.postgresql.Driver
   clusterStatsConfiguration:
     monitorType: INFO_API
-  modules:
-    - io.trino.gateway.ha.module.HaGatewayProviderModule
-    - io.trino.gateway.ha.module.ClusterStateListenerModule
-    - io.trino.gateway.ha.module.ClusterStatsMonitorModule
-  managedApps:
-    - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
 
 # -- Startup command for Trino Gateway process. Add additional Java options and other modifications as desired.
 command:

--- a/tests/gateway/test-values-with-env.yaml
+++ b/tests/gateway/test-values-with-env.yaml
@@ -17,12 +17,6 @@ config:
     driver: org.postgresql.Driver
   clusterStatsConfiguration:
     monitorType: INFO_API
-  modules:
-    - io.trino.gateway.ha.module.HaGatewayProviderModule
-    - io.trino.gateway.ha.module.ClusterStateListenerModule
-    - io.trino.gateway.ha.module.ClusterStatsMonitorModule
-  managedApps:
-    - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
 
 envFrom:
   - secretRef:

--- a/tests/gateway/test-values.yaml
+++ b/tests/gateway/test-values.yaml
@@ -17,12 +17,6 @@ config:
     driver: org.postgresql.Driver
   clusterStatsConfiguration:
     monitorType: INFO_API
-  modules:
-    - io.trino.gateway.ha.module.HaGatewayProviderModule
-    - io.trino.gateway.ha.module.ClusterStateListenerModule
-    - io.trino.gateway.ha.module.ClusterStatsMonitorModule
-  managedApps:
-    - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
 
 ingress:
   enabled: true


### PR DESCRIPTION
Remove `HaGatewayProviderModule`, `ActiveClusterMonitor`, `ClusterStateListenerModule`,
and `ClusterStatsMonitorModule` from Trino Gateway config file.
Gateway loads fundamental modules by default after https://github.com/trinodb/trino-gateway/pull/597.
This PR should be merged together with Trino Gateway 14 upgrade.