### PR TITLE
WIP: Add full TLS support

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -62,7 +62,7 @@ data:
     memory.heap-headroom-per-node={{ .Values.coordinator.config.memory.heapHeadroomPerNode }}
     {{- end }}
     {{- if .Values.server.config.https.internal }}
-    discovery.uri=https://localhost:{{ .Values.service.port }}
+    discovery.uri=https://localhost:{{ .Values.service.tlsPort }}
     {{- else }}
     discovery.uri=http://localhost:{{ .Values.service.port }}
     {{- end }}

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -61,7 +61,11 @@ data:
     {{- if .Values.coordinator.config.memory.heapHeadroomPerNode }}
     memory.heap-headroom-per-node={{ .Values.coordinator.config.memory.heapHeadroomPerNode }}
     {{- end }}
+    {{- if .Values.server.config.https.internal }}
+    discovery.uri=https://localhost:{{ .Values.service.port }}
+    {{- else }}
     discovery.uri=http://localhost:{{ .Values.service.port }}
+    {{- end }}
     {{- if .Values.server.config.authenticationType }}
     http-server.authentication.type={{ .Values.server.config.authenticationType }}
     {{- end }}
@@ -72,6 +76,13 @@ data:
     http-server.https.enabled=true
     http-server.https.port={{ .Values.server.config.https.port }}
     http-server.https.keystore.path={{ .Values.server.config.https.keystore.path }}
+    http-server.https.keystore.key={{ .Values.server.config.https.keystore.key }}
+    http-server.https.keymanager.password={{ .Values.server.config.https.keymanager.password }}
+    http-server.https.truststore.path={{ .Values.server.config.https.truststore.path }}
+    http-server.https.truststore.key={{ .Values.server.config.https.truststore.key }}
+    {{- if .Values.server.config.https.internal }}
+    internal-communication.https.required=true
+    {{- end }}
     {{- end }}
     {{- if $coordinatorJmx.enabled }}
     jmx.rmiregistry.port={{- $coordinatorJmx.registryPort }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -59,7 +59,7 @@ data:
     {{- end }}
     {{- if .Values.server.config.https.internal }}
     internal-communication.https.required=true
-    discovery.uri=https://{{ template "trino.fullname" . }}:{{ .Values.service.port }}
+    discovery.uri=https://{{ template "trino.fullname" . }}:{{ .Values.service.tlsPort }}
     http-server.https.enabled=true
     http-server.https.port={{ .Values.server.config.https.port }}
     {{- else }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -57,7 +57,14 @@ data:
     {{- if .Values.worker.config.memory.heapHeadroomPerNode }}
     memory.heap-headroom-per-node={{ .Values.worker.config.memory.heapHeadroomPerNode }}
     {{- end }}
+    {{- if .Values.server.config.https.internal }}
+    internal-communication.https.required=true
+    discovery.uri=https://{{ template "trino.fullname" . }}:{{ .Values.service.port }}
+    http-server.https.enabled=true
+    http-server.https.port={{ .Values.server.config.https.port }}
+    {{- else }}
     discovery.uri=http://{{ template "trino.fullname" . }}:{{ .Values.service.port }}
+    {{- end }}
     {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
     {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -50,6 +50,7 @@ server:
     path: /etc/trino
     https:
       enabled: false
+      internal: false
       port: 8443
       keystore:
         path: ""

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -429,6 +429,7 @@ service:
   annotations: {}
   type: ClusterIP
   port: 8080
+  tlsPort: 8443
   # service.nodePort -- The port the service listens on the host, for the `NodePort` type. If not set, Kubernetes will
   # [allocate a port
   # automatically](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport-custom-port).

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -54,12 +54,12 @@ server:
       port: 8443
       keystore:
         path: ""
-	key: ""
+        key: ""
       keymanager:
-	password: ""
+        password: ""
       truststore:
-	path: ""
-	key: ""
+        path: ""
+        key: ""
     # -- Trino supports multiple [authentication
     # types](https://trino.io/docs/current/security/authentication-types.html):
     # PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS.

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -54,6 +54,12 @@ server:
       port: 8443
       keystore:
         path: ""
+	key: ""
+      keymanager:
+	password: ""
+      truststore:
+	path: ""
+	key: ""
     # -- Trino supports multiple [authentication
     # types](https://trino.io/docs/current/security/authentication-types.html):
     # PASSWORD, CERTIFICATE, OAUTH2, JWT, KERBEROS.


### PR DESCRIPTION
DONE:
* Internal communication in https
* discovery scheme in https
* truststore path and key

TODO:
* Add automatically the https port to coordinator service
* Add automatically the https port to worker service when internal communication is https
* Debug rediness and livenessProbe when https only (no http server at all)
* Debug Ingress when https only