### PR TITLE
Update config path path for Trino Gateway and release chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the name to get an output similar to the following:
 ```
 NAME               	CHART VERSION	APP VERSION	DESCRIPTION
 trino/trino        	1.37.0       	470        	Fast distributed SQL query engine for big data ...
-trino/trino-gateway	1.14.0       	14         	A Helm chart for Trino Gateway
+trino/trino-gateway	1.15.0       	15         	A Helm chart for Trino Gateway
 ```
 
 Use `helm search repo trino -l` for information about all available versions.

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trino-gateway
 description: A Helm chart for Trino Gateway
 type: application
-version: "1.14.0"
-appVersion: "14"
+version: "1.15.0"
+appVersion: "15"
 
 icon: https://trino.io/assets/images/logos/trino-gateway-small.png
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -47,7 +47,7 @@ A Helm chart for Trino Gateway
 * `config.dataStore.password` - string, default: `"mysecretpassword"`
 * `config.dataStore.driver` - string, default: `"org.postgresql.Driver"`
 * `config.clusterStatsConfiguration.monitorType` - string, default: `"INFO_API"`
-* `command` - list, default: `["java","-XX:MinRAMPercentage=80.0","-XX:MaxRAMPercentage=80.0","-jar","/usr/lib/trino/gateway-ha-jar-with-dependencies.jar","/etc/gateway/config.yaml"]`  
+* `command` - list, default: `["java","-XX:MinRAMPercentage=80.0","-XX:MaxRAMPercentage=80.0","-jar","/usr/lib/trino-gateway/gateway-ha-jar-with-dependencies.jar","/etc/trino-gateway/config.yaml"]`  
 
   Startup command for Trino Gateway process. Add additional Java options and other modifications as desired.
 * `service` - object, default: `{"ports":[{"name":"gateway","protocol":"TCP"}],"type":"ClusterIP"}`  

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1,6 +1,6 @@
 # trino-gateway
 
-![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 14](https://img.shields.io/badge/AppVersion-14-informational?style=flat-square)
+![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15](https://img.shields.io/badge/AppVersion-15-informational?style=flat-square)
 
 A Helm chart for Trino Gateway
 

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: trino-gateway-configuration
-              mountPath: "/etc/gateway/config.yaml"
+              mountPath: "/etc/trino-gateway/config.yaml"
               subPath: "config.yaml"
               readOnly: true
           {{- with .Values.volumeMounts }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -50,8 +50,8 @@ command:
   - "-XX:MinRAMPercentage=80.0"
   - "-XX:MaxRAMPercentage=80.0"
   - "-jar"
-  - "/usr/lib/trino/gateway-ha-jar-with-dependencies.jar"
-  - "/etc/gateway/config.yaml"
+  - "/usr/lib/trino-gateway/gateway-ha-jar-with-dependencies.jar"
+  - "/etc/trino-gateway/config.yaml"
 
 # -- Service for accessing the gateway. The contents of this dictionary are used
 #  for the [service spec](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport).

--- a/tests/gateway/test-https.yaml
+++ b/tests/gateway/test-https.yaml
@@ -3,7 +3,7 @@ command:
   - "-c"
   - |
     cat /etc/certificates/tls.crt /etc/certificates/tls.key > /etc/scratch/tls.pem && \
-    java -XX:MinRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -jar /usr/lib/trino/gateway-ha-jar-with-dependencies.jar /etc/gateway/config.yaml
+    java -XX:MinRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -jar /usr/lib/trino-gateway/gateway-ha-jar-with-dependencies.jar /etc/trino-gateway/config.yaml
 
 config:
   serverConfig:


### PR DESCRIPTION
**Merge after upgrade to Trino Gateway 15**

Update config path path for gateway.

Changes:
* `/etc/gateway/config.yaml` to `/etc/trino-gateway/config.yaml`
* `/usr/lib/trino` -> `/usr/lib/trino-gateway`

Ref:
* https://github.com/trinodb/trino-gateway/pull/623
* https://github.com/trinodb/trino-gateway/pull/628