### PR TITLE
Release Trino Gateway chart 1.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the name to get an output similar to the following:
 ```
 NAME               	CHART VERSION	APP VERSION	DESCRIPTION
 trino/trino        	1.37.0       	470        	Fast distributed SQL query engine for big data ...
-trino/trino-gateway	1.14.0       	14         	A Helm chart for Trino Gateway
+trino/trino-gateway	1.15.0       	15         	A Helm chart for Trino Gateway
 ```
 
 Use `helm search repo trino -l` for information about all available versions.

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trino-gateway
 description: A Helm chart for Trino Gateway
 type: application
-version: "1.14.0"
-appVersion: "14"
+version: "1.15.0"
+appVersion: "15"
 
 icon: https://trino.io/assets/images/logos/trino-gateway-small.png
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1,6 +1,6 @@
 # trino-gateway
 
-![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 14](https://img.shields.io/badge/AppVersion-14-informational?style=flat-square)
+![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15](https://img.shields.io/badge/AppVersion-14-informational?style=flat-square)
 
 A Helm chart for Trino Gateway
 


### PR DESCRIPTION
To be merged after https://github.com/trinodb/trino-gateway/pull/620 and the 15 release and https://github.com/trinodb/charts/pull/310

Not sure how we best order these merges .. any idea @willmostly @nineinchnick and @oneonestar ?