### PR TITLE
Enable templating of environment name

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -48,7 +48,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
     - name: registry-credentials
   ```
 * `server.workers` - int, default: `2`
-* `server.node.environment` - string, default: `"production"`
+* `server.node.environment` - string, default: `"production"`  
+
+  Supports templating with `tpl`.
 * `server.node.dataDir` - string, default: `"/data/trino"`
 * `server.node.pluginDir` - string, default: `"/usr/lib/trino/plugin"`
 * `server.log.trino.level` - string, default: `"INFO"`

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: coordinator
 data:
   node.properties: |
-    node.environment={{ .Values.server.node.environment }}
+    node.environment={{ tpl .Values.server.node.environment . }}
     node.data-dir={{ .Values.server.node.dataDir }}
     plugin.dir={{ .Values.server.node.pluginDir }}
   {{- range $configValue := .Values.additionalNodeProperties }}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: worker
 data:
   node.properties: |
-    node.environment={{ .Values.server.node.environment }}
+    node.environment={{ tpl .Values.server.node.environment . }}
     node.data-dir={{ .Values.server.node.dataDir }}
     plugin.dir={{ .Values.server.node.pluginDir }}
   {{- range $configValue := .Values.additionalNodeProperties }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -40,6 +40,7 @@ imagePullSecrets: []
 server:
   workers: 2
   node:
+    # server.node.environment -- Supports templating with `tpl`.
     environment: production
     dataDir: /data/trino
     pluginDir: /usr/lib/trino/plugin

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -2,7 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  env: "dev"
+  region: "region_test"
+
 server:
+  node:
+    environment: "{{ .Values.global.env }}_{{ .Values.global.region }}"
   workers: 0
   config:
     https:


### PR DESCRIPTION
Support templating of the environment name.

This has two advantages:

- Avoid duplication of the environment name between trino and other parts of the deployment. _YAML anchors would still add substantial boilerplate_.
- Allows the existing environment name to be modified to meet trino naming requirements (e.g replacing dash with underscore).

For example...

values.yaml
```
trino:
  server:
    node:
      environment: "{{ .Values.global.env | replace \"-\" \"_\" }}"
```

values-dev-region-a.yaml
```
global:
  env: "dev-region-a"
```

