### PR TITLE
Include namespace in port-forward command

### DIFF
--- a/charts/trino/templates/NOTES.txt
+++ b/charts/trino/templates/NOTES.txt
@@ -4,7 +4,6 @@ Get the application URL by running these commands:
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} --selector "app.kubernetes.io/name={{ template "trino.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=coordinator" --output name)
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ template "trino.fullname" . }} 8080:{{ .Values.service.port }}
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:8080
 {{- end }}


### PR DESCRIPTION
This is really minor change to add the namespace to the kubectl port-forward command output after deploying the chart.

The change already exists in the gateway chart, so just adds the same for trino.