### PR TITLE
Don't require adding the https port in `additionalExposedPorts` when https is enabled

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -197,6 +197,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.server.config.https.enabled }}
+            - name: https
+              containerPort: {{ .Values.server.config.https.port }}
+              protocol: TCP
+            {{- end }}
             {{- if $coordinatorJmx.enabled }}
             - name: jmx-registry
               containerPort: {{ $coordinatorJmx.registryPort }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -171,6 +171,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.server.config.https.enabled }}
+            - name: https
+              containerPort: {{ .Values.server.config.https.port }}
+              protocol: TCP
+            {{- end }}
             {{- if $workerJmx.enabled }}
             - name: jmx-registry
               containerPort: {{ $workerJmx.registryPort }}

--- a/charts/trino/templates/ingress.yaml
+++ b/charts/trino/templates/ingress.yaml
@@ -32,7 +32,11 @@ spec:
               service:
                 name: {{ include "trino.fullname" $ }}
                 port:
+                  {{- if $.Values.server.config.https.enabled }}
+                  number: {{ $.Values.server.config.https.port }}
+                  {{- else }}
                   number: {{ $.Values.service.port }}
+                  {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/trino/templates/service-coordinator.yaml
+++ b/charts/trino/templates/service-coordinator.yaml
@@ -19,6 +19,12 @@ spec:
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    {{- if .Values.server.config.https.enabled }}
+    - port: {{ .Values.server.config.https.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    {{- end }}
     {{- if $coordinatorJmx.exporter.enabled }}
     - port: {{ $coordinatorJmx.exporter.port }}
       targetPort: jmx-exporter

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -100,13 +100,6 @@ coordinator:
       mountPath: /etc/trino/generated
       readOnly: false
 
-  additionalExposedPorts:
-    https:
-      servicePort: 8443
-      name: https
-      port: 8443
-      protocol: TCP
-
   annotations:
     custom/name: value
 


### PR DESCRIPTION
The changes below are a subset of the changes seen in #300 but the PR hasn't seen activity in over a month so I thought it might make sense to create this small PR. The changes in this PR are also independent of the other changes proposed by #300 to support internal TLS.