### PR TITLE
Fix secret naming consistency

### DIFF
--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: trino-gateway-configuration
+            - name: {{ include "trino-gateway.fullname" . }}-configuration
               mountPath: "/etc/trino-gateway/config.yaml"
               subPath: "config.yaml"
               readOnly: true
@@ -92,9 +92,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        - name: trino-gateway-configuration
+        - name: {{ include "trino-gateway.fullname" . }}-configuration
           secret:
-              secretName: trino-gateway-configuration
+              secretName: {{ include "trino-gateway.fullname" . }}-configuration
               optional: false
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/gateway/templates/secrets.yaml
+++ b/charts/gateway/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: trino-gateway-configuration
+    name: {{ include "trino-gateway.fullname" . }}-configuration
 type: "Opaque"
 data:
     config.yaml: "{{toYaml .Values.config | b64enc}}"


### PR DESCRIPTION
Ensure the secret and volume names dynamically use the chart's full name instead of a hardcoded value, aligning with Helm best practices and preventing naming conflicts in multi-instance deployments.

- Replace static references (`trino-gateway-configuration`) with templated Helm function (`{{ include "trino-gateway.fullname" . }}-configuration`).
- Update secret definition in `secrets.yaml`.
- Update volume mounts and secret references in `deployment.yaml`.