### PR TITLE
Use worker's additional exposed ports in the worker service

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -632,7 +632,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `worker.additionalJVMConfig` - list, default: `[]`
 * `worker.additionalExposedPorts` - object, default: `{}`  
 
-  Additional container ports configured in all worker pods.
+  Additional container ports configured in all worker pods and the worker service.
   Example:
   ```yaml
    https:

--- a/charts/trino/templates/service-worker.yaml
+++ b/charts/trino/templates/service-worker.yaml
@@ -22,6 +22,15 @@ spec:
       protocol: TCP
       name: jmx-exporter
     {{- end }}
+    {{- range $key, $value := .Values.worker.additionalExposedPorts }}
+    - port: {{ $value.servicePort }}
+      name: {{ $value.name }}
+      targetPort: {{ $value.port }}
+      protocol: {{ $value.protocol }}
+      {{- if $value.nodePort }}
+      nodePort: {{ $value.nodePort }}
+      {{- end }}
+    {{- end }}
   selector:
     {{- include "trino.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: worker

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -754,7 +754,7 @@ worker:
   additionalJVMConfig: []
 
   additionalExposedPorts: {}
-  # worker.additionalExposedPorts -- Additional container ports configured in all worker pods.
+  # worker.additionalExposedPorts -- Additional container ports configured in all worker pods and the worker service.
   # @raw
   # Example:
   # ```yaml

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -134,6 +134,13 @@ worker:
     query:
       maxMemoryPerNode: "2GB"
 
+  additionalExposedPorts:
+    extra-port:
+      servicePort: 9483
+      name: extra-port
+      port: 9483
+      protocol: TCP
+
   annotations:
     custom/name: value
 


### PR DESCRIPTION
Currently additionaly exposed ports are not added to trino  worker service. This change will add them.