### PR TITLE
Add configurable topologySpreadConstraints for Trino gateway deployment

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -120,19 +120,18 @@ A Helm chart for Trino Gateway
 * `volumeMounts` - object, default: `{}`
 * `nodeSelector` - object, default: `{}`
 * `tolerations` - list, default: `[]`
-* `topologySpreadConstraints` - list, default: `[]`
- 
-   [Deployment Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) configuration. <br>
-   Useful to control how Pods are spread across domains such as regions, zones, nodes etc. Example:
+* `topologySpreadConstraints` - list, default: `[]`  
+
+  [Deployment Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) configuration. Useful to control how Pods are spread across domains such as regions, zones, nodes etc.
+  Example:
   ```yaml
    - maxSkew: 1
-    topologyKey: "kubernetes.io/hostname"
-    whenUnsatisfiable: ScheduleAnyway
+     topologyKey: "kubernetes.io/hostname"
+     whenUnsatisfiable: ScheduleAnyway
    - maxSkew: 1
-    topologyKey: "topology.kubernetes.io/zone"
-    whenUnsatisfiable: ScheduleAnyway
-   ```
-
+     topologyKey: "topology.kubernetes.io/zone"
+     whenUnsatisfiable: ScheduleAnyway
+  ```
 * `affinity` - object, default: `{}`
 * `commonLabels` - object, default: `{}`  
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -120,6 +120,7 @@ A Helm chart for Trino Gateway
 * `volumeMounts` - object, default: `{}`
 * `nodeSelector` - object, default: `{}`
 * `tolerations` - list, default: `[]`
+* `topologySpreadConstraints` - list, default: `[]`
 * `affinity` - object, default: `{}`
 * `commonLabels` - object, default: `{}`  
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -121,6 +121,18 @@ A Helm chart for Trino Gateway
 * `nodeSelector` - object, default: `{}`
 * `tolerations` - list, default: `[]`
 * `topologySpreadConstraints` - list, default: `[]`
+ 
+   [Deployment Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) configuration. <br>
+   Useful to control how Pods are spread across domains such as regions, zones, nodes etc. Example:
+  ```yaml
+   - maxSkew: 1
+    topologyKey: "kubernetes.io/hostname"
+    whenUnsatisfiable: ScheduleAnyway
+   - maxSkew: 1
+    topologyKey: "topology.kubernetes.io/zone"
+    whenUnsatisfiable: ScheduleAnyway
+   ```
+
 * `affinity` - object, default: `{}`
 * `commonLabels` - object, default: `{}`  
 

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -111,3 +111,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -163,6 +163,19 @@ nodeSelector: {}
 tolerations: []
 
 topologySpreadConstraints: []
+# topologySpreadConstraints -- [Deployment Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) configuration.
+# Useful to control how Pods are spread across domains such as regions, zones, nodes etc.
+# @raw
+# Example:
+# ```yaml
+#  - maxSkew: 1
+#    topologyKey: "kubernetes.io/hostname"
+#    whenUnsatisfiable: ScheduleAnyway
+#  - maxSkew: 1
+#    topologyKey: "topology.kubernetes.io/zone"
+#    whenUnsatisfiable: ScheduleAnyway
+# ```
+
 
 affinity: {}
 

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -162,6 +162,8 @@ nodeSelector: {}
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 affinity: {}
 
 # -- Labels that get applied to every resource's metadata


### PR DESCRIPTION
Allow [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to be configurable for the Trino gateway deployment. 
A common usecase for this would be ensuring that pods are available in multiple AZ to make the Trino gateway deployment more resilient to single AZ failures. 