### PR TITLE
add extradeploy

### DIFF
--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -155,3 +155,16 @@ Create the secret name for the group-provider file
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "trino.extradeploy.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}

--- a/charts/trino/templates/extradeploy.yaml
+++ b/charts/trino/templates/extradeploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/trino/templates/extradeploy.yaml
+++ b/charts/trino/templates/extradeploy.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraDeploy }}
 ---
-{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "trino.extradeploy.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -1134,3 +1134,5 @@ networkPolicy:
   #        port: 9999
   # ```
   egress: []
+
+extraDeploy: {}


### PR DESCRIPTION
I suggest adding the ability to deploy additional kubrnetes objects to chart. For example, I needed to deploy an object 
<pre>

-  apiVersion: external-secrets.io/v1beta1
   kind: ExternalSecret
      name: external-secret
   spec:
      refreshInterval: 1h
      secretStoreRef:
        name: trino
        kind: SecretStore
      target:
        name: external-secret
      dataFrom:
        - extract:
            key: secrets/trino
            
</pre>
