### PR TITLE
Run CI tests only if Trino and Gateway file change

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -54,8 +54,6 @@ jobs:
               - '.helmignore'
               - '.github/**'
               - '.gitignore'
-          # For PRs, use the base commit SHA; for Push events, use the commit before the current one
-          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
   test:
     runs-on: ubuntu-latest
@@ -126,7 +124,7 @@ jobs:
   sync-readme:
     needs: [lint, test, test-gateway, docs]
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: ${{ always() && !failure() && github.event_name != 'pull_request'}}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -155,7 +153,7 @@ jobs:
   release:
     needs: [lint, test, test-gateway, docs, sync-readme]
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: ${{ always() && !failure() && github.event_name != 'pull_request'}}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -28,9 +28,40 @@ jobs:
       - name: Lint charts
         run: ct lint --charts=charts/trino,charts/gateway --validate-maintainers=false
 
+  changes:
+    runs-on: ubuntu-latest
+    name: changed trino/gateway files
+    outputs:
+      trino-changed: ${{ steps.filter.outputs.trino }}
+      gateway-changed: ${{ steps.filter.outputs.gateway }}
+    steps:
+      - uses: actions/checkout@v4
+      # Detect changes in trino/gatway files to conditionally run tests
+      - name: Get changed related files
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: filter
+        with:
+          filters: |
+            trino:
+              - 'charts/trino/**'
+              - 'tests/trino/**'
+              - '.helmignore'
+              - '.github/**'
+              - '.gitignore'
+            gateway:
+              - 'charts/gateway/**'
+              - 'tests/gateway/**'
+              - '.helmignore'
+              - '.github/**'
+              - '.gitignore'
+          # For PRs, use the base commit SHA; for Push events, use the commit before the current one
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+
   test:
     runs-on: ubuntu-latest
     name: test trino ${{ matrix.label }}
+    needs: [changes]
+    if: ${{needs.changes.outputs.trino-changed == 'true'}}
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +91,8 @@ jobs:
   test-gateway:
     runs-on: ubuntu-latest
     name: test gateway ${{ matrix.label }}
+    needs: [changes]
+    if: ${{needs.changes.outputs.gateway-changed == 'true'}}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request updates the CI/CD workflow to conditionally run tests (https://github.com/trinodb/charts/issues/345). The kind cluster setup and tests will be skipped if there are no changes detected in pull requests or push events.


**Trino Tests**:  detect changes in 
- `charts/trino/**`, 
- `tests/trino/**`, 
- `.helmignore` 
- `.github/**`
- `.gitignore`

**Gateway Tests**:  detect changes in 
- `charts/gateway/**`, 
- `tests/gateway/**`, 
- `.helmignore` 
- `.github/**`
- `.gitignore`