### PR TITLE
Add labels to the trino-gateway-configuration secret

### DIFF
--- a/charts/gateway/templates/secrets.yaml
+++ b/charts/gateway/templates/secrets.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: {{ include "trino-gateway.fullname" . }}-configuration
+  name: {{ include "trino-gateway.fullname" . }}-configuration
+  labels:
+    {{- include "trino-gateway.labels" . | nindent 4 }}
 type: "Opaque"
 data:
-    config.yaml: "{{toYaml .Values.config | b64enc}}"
+  config.yaml: {{ .Values.config | toYaml | b64enc | quote }}


### PR DESCRIPTION
Made minor adjustments to the `trino-gateway-configuration` Secret, fixed indentation & added metadata labels to enhance consistency & readability.