### PR TITLE
Add topologySpreadConstraints for coordinator

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -569,6 +569,27 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `coordinator.nodeSelector` - object, default: `{}`
 * `coordinator.tolerations` - list, default: `[]`
 * `coordinator.affinity` - object, default: `{}`
+* `coordinator.topologySpreadConstraints` - list, default: `[]`  
+
+  Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to control how coordinator pods are spread across your cluster among failure-domains such as nodes, zones, and regions.
+  Example of spreading coordinators across hostnames and zones:
+  ```yaml
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: "kubernetes.io/hostname"
+      whenUnsatisfiable: "ScheduleAnyway"
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: trino
+          app.kubernetes.io/component: coordinator
+    - maxSkew: 1
+      topologyKey: "topology.kubernetes.io/zone"
+      whenUnsatisfiable: "DoNotSchedule"
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: trino
+          app.kubernetes.io/component: coordinator
+  ```
 * `coordinator.additionalConfigFiles` - object, default: `{}`  
 
   Additional config files placed in the default configuration directory. Supports templating the files' contents with `tpl`.

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -262,6 +262,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.coordinator.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.coordinator.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -664,6 +664,32 @@ coordinator:
 
   affinity: {}
 
+  topologySpreadConstraints: []
+  # coordinator.topologySpreadConstraints -- Configure [topology spread
+  # constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  # to control how coordinator pods are spread across your cluster among failure-domains
+  # such as nodes, zones, and regions.
+  #
+  # @raw
+  # Example of spreading coordinator across hostnames and zones:
+  # ```yaml
+  # topologySpreadConstraints:
+  #   - maxSkew: 1
+  #     topologyKey: "kubernetes.io/hostname"
+  #     whenUnsatisfiable: "ScheduleAnyway"
+  #     labelSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: trino
+  #         app.kubernetes.io/component: coordinator
+  #   - maxSkew: 1
+  #     topologyKey: "topology.kubernetes.io/zone"
+  #     whenUnsatisfiable: "DoNotSchedule"
+  #     labelSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: trino
+  #         app.kubernetes.io/component: coordinator
+  # ```
+  
   additionalConfigFiles: {}
   # coordinator.additionalConfigFiles -- Additional config files placed in the default configuration directory.
   # Supports templating the files' contents with `tpl`.

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -103,6 +103,22 @@ coordinator:
   annotations:
     custom/name: value
 
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: "kubernetes.io/hostname"
+      whenUnsatisfiable: "ScheduleAnyway"
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: trino
+          app.kubernetes.io/component: coordinator
+    - maxSkew: 1
+      topologyKey: "topology.kubernetes.io/zone"
+      whenUnsatisfiable: "ScheduleAnyway"
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: trino
+          app.kubernetes.io/component: coordinator
+
 worker:
   deployment:
     annotations:


### PR DESCRIPTION
A follow up from #358  to add topologySpreadConstraints to coordinator deployment as well. As some orgs require all deployments to have this configuration.

I've used the existing comments for the worker's topologySpreadConstraints to keep a consistent documentation. 