### PR TITLE
Fix group auth secret not injected correctly

### DIFF
--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -138,7 +138,7 @@ data:
     file.password-file={{ .Values.server.config.path }}/auth/password/password.db
   {{- end }}{{- end }}
 
-  {{- if .Values.auth.groups }}{{- if not (index .Values.coordinator.additionalConfigFiles "group-provider.properties") }}
+  {{- if or .Values.auth.groups .Values.auth.groupsAuthSecret }}{{- if not (index .Values.coordinator.additionalConfigFiles "group-provider.properties") }}
   group-provider.properties: |
     group-provider.name=file
     file.group-file={{ .Values.server.config.path }}/auth/group/group.db


### PR DESCRIPTION
Although the chart support passing external secret as group db via `groupAuthSecret` besides adding directly to `groups` under `auth` section , there is some typos and logic missing causing `group-provider.properties` not being created, leads to the rendered `group.db` not being injected into the cluster