### PR TITLE
Remove default deployment strategy values

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -504,7 +504,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `coordinator.deployment.revisionHistoryLimit` - int, default: `10`  
 
   The number of old ReplicaSets to retain to allow rollback.
-* `coordinator.deployment.strategy` - object, default: `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}`  
+* `coordinator.deployment.strategy` - object, default: `{}`  
 
   The deployment strategy to use to replace existing pods with new ones.
 * `coordinator.jvm.maxHeapSize` - string, default: `"8G"`
@@ -642,7 +642,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `worker.deployment.revisionHistoryLimit` - int, default: `10`  
 
   The number of old ReplicaSets to retain to allow rollback.
-* `worker.deployment.strategy` - object, default: `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}`  
+* `worker.deployment.strategy` - object, default: `{}`  
 
   The deployment strategy to use to replace existing pods with new ones.
 * `worker.jvm.maxHeapSize` - string, default: `"8G"`

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -17,8 +17,10 @@ spec:
   replicas: 1
   progressDeadlineSeconds: {{ .Values.coordinator.deployment.progressDeadlineSeconds }}
   revisionHistoryLimit: {{ .Values.coordinator.deployment.revisionHistoryLimit }}
+  {{- if .Values.coordinator.deployment.strategy }}
   strategy:
     {{- toYaml .Values.coordinator.deployment.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "trino.selectorLabels" . | nindent 6 }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -17,8 +17,10 @@ metadata:
 spec:
   progressDeadlineSeconds: {{ .Values.worker.deployment.progressDeadlineSeconds }}
   revisionHistoryLimit: {{ .Values.worker.deployment.revisionHistoryLimit }}
+  {{- if .Values.worker.deployment.strategy }}
   strategy:
     {{- toYaml .Values.worker.deployment.strategy | nindent 4 }}
+  {{- end }}
   {{- if and (not .Values.server.autoscaling.enabled) (not .Values.server.keda.enabled) }}
   replicas: {{ .Values.server.workers }}
   {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -605,11 +605,7 @@ coordinator:
     revisionHistoryLimit: 10
     # coordinator.deployment.revisionHistoryLimit -- The number of old ReplicaSets to retain to allow rollback.
 
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 25%
-        maxUnavailable: 25%
+    strategy: {}
     # coordinator.deployment.strategy -- The deployment strategy to use to replace existing pods with new ones.
 
   jvm:
@@ -790,11 +786,7 @@ worker:
     revisionHistoryLimit: 10
     # worker.deployment.revisionHistoryLimit -- The number of old ReplicaSets to retain to allow rollback.
 
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 25%
-        maxUnavailable: 25%
+    strategy: {}
     # worker.deployment.strategy -- The deployment strategy to use to replace existing pods with new ones.
 
   jvm:


### PR DESCRIPTION
This PR updates the `trino/` Helm chart so that `coordinator/worker.deployment.strategy` is empty by default instead of pre-filled with a `RollingUpdate` default K8s configurations.

### Motivation:
Currently, the chart always renders a `.spec.strategy.rollingUpdate` block in the deployment manifest, even when users want to use `.spec.strategy.type==Recreate`. This leads to confusing output, especially when using wrapper charts (in which `rollingUpdate` is impossible to override) or custom values files (which make you set `rollingUpdate` to `null` while using `Recreate` type).
K8s fails to create the deployment when `.spec.strategy.rollingUpdate` appears in conjunction with `.spec.strategy.type==Recreate`.

### Solution:
The following changes eliminate the need for workarounds like `null` to override the `rollingUpdate` field, making it more flexible and user-friendly.

### Backward Compatibility:
The default behavior

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 25%
    maxUnavailable: 25%
```
is unchanged if users do not override strategy, as these are the default values according to [K8s official docs](http://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).