### PR TITLE
Add Pod Disruption Budget support to Trino chart

### DIFF
--- a/charts/trino/templates/poddisruptionbudget-coordinator.yaml
+++ b/charts/trino/templates/poddisruptionbudget-coordinator.yaml
@@ -1,0 +1,16 @@
+{{- with .Values.coordinator.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "trino.coordinator" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "trino.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  selector:
+    matchLabels:
+      {{- include "trino.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: coordinator
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/trino/templates/poddisruptionbudget-worker.yaml
+++ b/charts/trino/templates/poddisruptionbudget-worker.yaml
@@ -1,0 +1,18 @@
+{{- if gt (int .Values.server.workers) 0 }}
+{{- with .Values.worker.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "trino.worker" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "trino.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  selector:
+    matchLabels:
+      {{- include "trino.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: worker
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -612,6 +612,18 @@ coordinator:
         maxUnavailable: 25%
     # coordinator.deployment.strategy -- The deployment strategy to use to replace existing pods with new ones.
 
+  podDisruptionBudget: {}
+  # coordinator.podDisruptionBudget -- [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) configuration.
+  # @raw
+  # Example:
+  # ```yaml
+  #  minAvailable: 1
+  # ```
+  # or
+  # ```yaml
+  #  maxUnavailable: 1
+  # ```
+
   jvm:
     maxHeapSize: "8G"
     gcMethod:
@@ -796,6 +808,18 @@ worker:
         maxSurge: 25%
         maxUnavailable: 25%
     # worker.deployment.strategy -- The deployment strategy to use to replace existing pods with new ones.
+
+  podDisruptionBudget: {}
+  # worker.podDisruptionBudget -- [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) configuration.
+  # @raw
+  # Example:
+  # ```yaml
+  #  maxUnavailable: 1
+  # ```
+  # or
+  # ```yaml
+  #  minAvailable: 2
+  # ```
 
   jvm:
     maxHeapSize: "8G"


### PR DESCRIPTION
This commit adds Pod Disruption Budget (PDB) configuration options to the Trino Helm chart, bringing it to feature parity with the gateway chart which already has PDB support.

## Changes

### New Templates
- Added `poddisruptionbudget-coordinator.yaml` to manage coordinator pod disruptions
- Added `poddisruptionbudget-worker.yaml` to manage worker pod disruptions
  - Worker PDB is only created when `server.workers > 0` (not in single-node mode)

### Configuration
- Added `coordinator.podDisruptionBudget` configuration section in values.yaml
  - Supports both `minAvailable` and `maxUnavailable` strategies
  - Default is empty (no PDB created) for backward compatibility

- Added `worker.podDisruptionBudget` configuration section in values.yaml
  - Supports both `minAvailable` and `maxUnavailable` strategies
  - Default is empty (no PDB created) for backward compatibility

## Benefits

Pod Disruption Budgets help maintain application availability during voluntary disruptions such as:
- Node maintenance and upgrades
- Cluster autoscaling operations
- Rolling updates of the cluster

For Trino specifically:
- **Coordinator PDB**: Ensures the coordinator remains available during disruptions, preventing complete query processing outages
- **Worker PDB**: Controls the rate at which workers can be disrupted, maintaining query processing capacity

## Usage Examples

```yaml
# Ensure at least 1 coordinator is always available
coordinator:
  podDisruptionBudget:
    minAvailable: 1

# Allow at most 1 worker to be unavailable at a time
worker:
  podDisruptionBudget:
    maxUnavailable: 1
```

## Testing

Verified that:
- Templates render correctly with various PDB configurations
- PDBs are not created when not configured (backward compatible)
- Worker PDB is correctly omitted in single-node mode
- Label selectors properly match coordinator and worker pods

🤖 Generated with [Claude Code](https://claude.ai/code)