### PR TITLE
#380 Add support for setting priorityClassName for coordinator and workers

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -598,6 +598,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    - name: extras
      mountPath: /usr/share/extras
      readOnly: true
+* `coordinator.priorityClassName` - string, default: `nil`
 * `coordinator.annotations` - object, default: `{}`  
 
   Annotations to add to the coordinator pod.
@@ -764,6 +765,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
      mountPath: /usr/share/extras
      readOnly: true
   ```
+* `worker.priorityClassName` - string, default: `nil`
 * `worker.annotations` - object, default: `{}`  
 
   Annotations to add to the worker pods.

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -47,6 +47,9 @@ spec:
         {{- tpl (toYaml .Values.coordinator.labels) . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.coordinator.priorityClassName }}
+      priorityClassName: {{ .Values.coordinator.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}
       securityContext:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -49,6 +49,9 @@ spec:
         {{- tpl (toYaml .Values.worker.labels) . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.worker.priorityClassName }}
+      priorityClassName: {{ .Values.worker.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "trino.serviceAccountName" . }}
       {{- with .Values.securityContext }}
       securityContext:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -731,6 +731,8 @@ coordinator:
   #    mountPath: /usr/share/extras
   #    readOnly: true
 
+  priorityClassName: ~
+
   annotations: {}
   # coordinator.annotations -- Annotations to add to the coordinator pod.
   # @raw
@@ -953,6 +955,8 @@ worker:
   #    mountPath: /usr/share/extras
   #    readOnly: true
   # ```
+
+  priorityClassName: ~
 
   annotations: {}
   # worker.annotations -- Annotations to add to the worker pods.


### PR DESCRIPTION
Issue #380 

In Kubernetes, `priorityClassName` is an important scheduling control that determines the relative importance of pods. By assigning a `PriorityClass`, cluster operators can ensure that critical workloads are scheduled before lower-priority ones and are less likely to be evicted under resource pressure.

In multi-tenant or shared Kubernetes clusters, resource contention is common. Without a `priorityClassName`, the pods may be scheduled with default priority, meaning they compete equally with less critical workloads. Allowing operators to assign a high priority ensures the pods are less likely to be preempted or evicted during node pressure events.

Supporting `priorityClassName` in the Helm chart improves reliability, aligns with Kubernetes best practices, and gives operators control over pod scheduling and eviction policies, all with minimal implementation overhead.