### PR TITLE
Refactor naming helpers to use centralized fullname function

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -20,7 +20,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
   coordinatorNameOverride: trino-coordinator-adhoc
   workerNameOverride: trino-worker-adhoc
   nameOverride: trino-adhoc
+  fullnameOverride: trino-adhoc
   ```
+* `fullnameOverride` - string, default: `nil`
 * `coordinatorNameOverride` - string, default: `nil`
 * `workerNameOverride` - string, default: `nil`
 * `image.registry` - string, default: `""`  

--- a/charts/trino/templates/_helpers.tpl
+++ b/charts/trino/templates/_helpers.tpl
@@ -35,12 +35,7 @@ Create chart name and version as used by the chart label.
 {{- if .Values.coordinatorNameOverride }}
 {{- .Values.coordinatorNameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if hasPrefix .Release.Name $name }}
-{{- printf "%s-%s" $name "coordinator" | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s-%s" .Release.Name $name "coordinator" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" (include "trino.fullname" .) "coordinator" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -48,12 +43,7 @@ Create chart name and version as used by the chart label.
 {{- if .Values.workerNameOverride }}
 {{- .Values.workerNameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if hasPrefix .Release.Name $name }}
-{{- printf "%s-%s" $name "worker" | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s-%s" .Release.Name $name "worker" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" (include "trino.fullname" .) "worker" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -131,12 +121,7 @@ Create the secret name for the file-based authentication's password file
 {{- if and .Values.auth .Values.auth.passwordAuthSecret }}
 {{- .Values.auth.passwordAuthSecret | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if hasPrefix .Release.Name $name }}
-{{- printf "%s-%s" $name "password-file" | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s-%s" .Release.Name $name "password-file" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" (include "trino.fullname" .) "password-file" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -147,11 +132,6 @@ Create the secret name for the group-provider file
 {{- if and .Values.auth .Values.auth.groupsAuthSecret }}
 {{- .Values.auth.groupsAuthSecret }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if hasPrefix .Release.Name $name }}
-{{- printf "%s-%s" $name "groups-file" | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s-%s" .Release.Name $name "groups-file" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" (include "trino.fullname" .) "groups-file" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -10,8 +10,10 @@
 # coordinatorNameOverride: trino-coordinator-adhoc
 # workerNameOverride: trino-worker-adhoc
 # nameOverride: trino-adhoc
+# fullnameOverride: trino-adhoc
 # ```
 nameOverride:
+fullnameOverride:
 coordinatorNameOverride:
 workerNameOverride:
 


### PR DESCRIPTION
Consolidates duplicate naming logic across coordinator, worker, and authentication secret helpers by leveraging the existing `trino.fullname` template helper.

This eliminates code duplication and ensures consistent naming behavior across all generated resource names. The change simplifies maintenance by centralizing the name generation logic in a single place, making future updates to naming conventions easier to implement.

Adds support for `fullnameOverride` configuration option to allow users to completely customize the full release name when needed.