### PR TITLE
feat(monitoring): add optional scrapeTimeout to ServiceMonitor

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -926,6 +926,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `serviceMonitor.interval` - string, default: `"30s"`  
 
   The serviceMonitor web endpoint interval
+* `serviceMonitor.scrapeTimeout` - string, default: `""`  
+
+  Maximum time to wait for a response. If empty or not set, uses the Prometheus global default.
 * `serviceMonitor.coordinator` - object, default: `{}`  
 
   Override ServiceMonitor configurations for the Trino coordinator.

--- a/charts/trino/templates/servicemonitor-coordinator.yaml
+++ b/charts/trino/templates/servicemonitor-coordinator.yaml
@@ -21,4 +21,7 @@ spec:
   endpoints:
     - port: jmx-exporter
       interval: {{ $coordinatorServiceMonitor.interval }}
+      {{- if $coordinatorServiceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ $coordinatorServiceMonitor.scrapeTimeout }}
+      {{- end }}
 {{- end }}

--- a/charts/trino/templates/servicemonitor-worker.yaml
+++ b/charts/trino/templates/servicemonitor-worker.yaml
@@ -21,4 +21,7 @@ spec:
   endpoints:
     - port: jmx-exporter
       interval: {{ $workerServiceMonitor.interval }}
+      {{- if $workerServiceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ $workerServiceMonitor.scrapeTimeout }}
+      {{- end }}
 {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -1133,6 +1133,9 @@ serviceMonitor:
     prometheus: kube-prometheus
   # serviceMonitor.interval -- The serviceMonitor web endpoint interval
   interval: "30s"
+  # serviceMonitor.scrapeTimeout -- Maximum time to wait for a response.
+  # If empty or not set, uses the Prometheus global default.
+  scrapeTimeout: ""
   coordinator: {}
   # serviceMonitor.coordinator -- Override ServiceMonitor configurations for the Trino coordinator.
   # @raw


### PR DESCRIPTION
## Summary
This PR adds an optional `scrapeTimeout` field to the `ServiceMonitor` template, defaulting to an empty string (`""`).

## Context / Motivation
Currently, users cannot override the `scrapeTimeout` in the ServiceMonitor. This makes it difficult to adjust for slow-responding Trino metrics endpoints, as they are forced to use the global Prometheus default (usually 10s) even if the scrape `interval` is much larger (30s).

## Changes
* **templates/servicemonitor.yaml**: Added `scrapeTimeout` field, wrapped in a conditional block. It only renders if a value is provided.
* **values.yaml**: Added `scrapeTimeout: ""` to the `serviceMonitor` section.

## How to Test
1.  **Default (Empty):** Deploy with `scrapeTimeout: ""`. Verify the `scrapeTimeout` field is **absent** from the generated YAML.
2.  **Custom:** Deploy with `scrapeTimeout: "25s"`. Verify the generated YAML contains `scrapeTimeout: 25s`.