### PR TITLE
[trino][catalogs] allow user catalogs own setup

### DIFF
--- a/charts/trino/templates/configmap-catalog.yaml
+++ b/charts/trino/templates/configmap-catalog.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.catalogs .Values.additionalCatalogs }}
+{{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -62,7 +62,7 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "trino.coordinator" . }}
-            {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
+          {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -31,7 +31,7 @@ spec:
         {{- if and (eq .Values.accessControl.type "configmap") (not .Values.accessControl.refreshPeriod) }}
         checksum/access-control-config: {{ include (print $.Template.BasePath "/configmap-access-control-coordinator.yaml") . | sha256sum }}
         {{- end }}
-        {{- if or .Values.catalogs .Values.additionalCatalogs }}
+        {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
         checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
         {{- end }}
         checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}
@@ -62,7 +62,7 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "trino.coordinator" . }}
-        {{- if or .Values.catalogs .Values.additionalCatalogs }}
+            {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
@@ -146,7 +146,7 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume
-            {{- if or .Values.catalogs .Values.additionalCatalogs }}
+              {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
             {{- end }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if or .Values.catalogs .Values.additionalCatalogs }}
+        {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
         checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
         {{- end }}
         checksum/worker-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
@@ -64,7 +64,7 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "trino.worker" . }}
-        {{- if or .Values.catalogs .Values.additionalCatalogs }}
+            {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
         - name: catalog-volume
           configMap:
             name: {{ template "trino.catalog" . }}
@@ -131,7 +131,7 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume
-            {{- if or .Values.catalogs .Values.additionalCatalogs }}
+              {{- if or .Values.additionalCatalogs (gt (len .Values.catalogs) 0) }}
             - mountPath: {{ .Values.server.config.path }}/catalog
               name: catalog-volume
             {{- end }}


### PR DESCRIPTION
Hello

Following https://github.com/trinodb/charts/pull/325

[trino][catalogs] allow user catalogs own setup: I would like to have my own catalogs implementation using a custom secret instead of configMap.

@nineinchnick can you please review this PR? Thanks
This replaces https://github.com/trinodb/charts/pull/327. Please see https://github.com/trinodb/charts/pull/327#issuecomment-4152405801