### PR TITLE
Release Trino Gateway chart 1.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the name to get an output similar to the following:
 ```
 NAME               	CHART VERSION	APP VERSION	DESCRIPTION
 trino/trino        	1.42.2       	480        	Fast distributed SQL query engine for big data ...
-trino/trino-gateway	1.18.0       	18         	A Helm chart for Trino Gateway
+trino/trino-gateway	1.19.0       	19         	A Helm chart for Trino Gateway
 ```
 
 Use `helm search repo trino -l` for information about all available versions.

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trino-gateway
 description: A Helm chart for Trino Gateway
 type: application
-version: "1.18.0"
-appVersion: "18"
+version: "1.19.0"
+appVersion: "19"
 
 icon: https://trino.io/assets/images/logos/trino-gateway-small.png
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1,6 +1,6 @@
 # trino-gateway
 
-![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 18](https://img.shields.io/badge/AppVersion-18-informational?style=flat-square)
+![Version: 1.19.0](https://img.shields.io/badge/Version-1.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 19](https://img.shields.io/badge/AppVersion-19-informational?style=flat-square)
 
 A Helm chart for Trino Gateway
 


### PR DESCRIPTION
Pending release of Trino Gateway 19 - see https://github.com/trinodb/trino-gateway/pull/950

Until then CI is expected to fail.