### PR TITLE
Add additional jvm heap configuration options

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -521,7 +521,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 
   The deployment strategy to use to replace existing pods with new ones.
 * `coordinator.jvm.maxHeapSize` - string, default: `"8G"`
-* `coordinator.jvm.minHeapSize` - string, default: `"8G"`
+* `coordinator.jvm.minHeapSize` - string, default: `nil`
 * `coordinator.jvm.maxHeapPercent` - string, default: `nil`  
 
   Alternative method of setting heap size as a percentage of container memory limits, which is recommended for better JVM ergonomics. `maxHeapSize` must be unset for this to work.
@@ -667,7 +667,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 
   The deployment strategy to use to replace existing pods with new ones.
 * `worker.jvm.maxHeapSize` - string, default: `"8G"`
-* `worker.jvm.minHeapSize` - string, default: `"8G"`
+* `worker.jvm.minHeapSize` - string, default: `nil`
 * `worker.jvm.maxHeapPercent` - string, default: `nil`
 * `worker.jvm.initialHeapPercent` - string, default: `nil`
 * `worker.jvm.gcMethod.type` - string, default: `"UseG1GC"`

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -521,6 +521,13 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 
   The deployment strategy to use to replace existing pods with new ones.
 * `coordinator.jvm.maxHeapSize` - string, default: `"8G"`
+* `coordinator.jvm.minHeapSize` - string, default: `"8G"`
+* `coordinator.jvm.maxHeapPercent` - string, default: `nil`  
+
+  Alternative method of setting heap size as a percentage of container memory limits, which is recommended for better JVM ergonomics. `maxHeapSize` must be unset for this to work.
+* `coordinator.jvm.initialHeapPercent` - string, default: `nil`  
+
+  sets the starting heap size as a percentage of container memory limits.  NOTE: to disable dynamic heap resizing when setting the size as a percent, add `-XX:MaxHeapFreeRatio=100` or `-XX:-UseAdaptiveSizePolicy` to `additionalJVMConfig`.
 * `coordinator.jvm.gcMethod.type` - string, default: `"UseG1GC"`
 * `coordinator.jvm.gcMethod.g1.heapRegionSize` - string, default: `"32M"`
 * `coordinator.config.memory.heapHeadroomPerNode` - string, default: `""`
@@ -660,6 +667,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 
   The deployment strategy to use to replace existing pods with new ones.
 * `worker.jvm.maxHeapSize` - string, default: `"8G"`
+* `worker.jvm.minHeapSize` - string, default: `"8G"`
+* `worker.jvm.maxHeapPercent` - string, default: `nil`
+* `worker.jvm.initialHeapPercent` - string, default: `nil`
 * `worker.jvm.gcMethod.type` - string, default: `"UseG1GC"`
 * `worker.jvm.gcMethod.g1.heapRegionSize` - string, default: `"32M"`
 * `worker.config.memory.heapHeadroomPerNode` - string, default: `""`

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -19,7 +19,18 @@ data:
   jvm.config: |
     -server
     -agentpath:/usr/lib/trino/bin/libjvmkill.so
+    {{- if .Values.coordinator.jvm.maxHeapSize }}
     -Xmx{{ .Values.coordinator.jvm.maxHeapSize }}
+    {{- end }}
+    {{- if .Values.coordinator.jvm.minHeapSize }}
+    -Xms{{ .Values.coordinator.jvm.minHeapSize }}
+    {{- end }}
+    {{- if .Values.coordinator.jvm.maxHeapPercent }}
+    -XX:MaxRAMPercentage={{ .Values.coordinator.jvm.maxHeapPercent }}
+    {{- end }}
+    {{- if .Values.coordinator.jvm.initialHeapPercent }}
+    -XX:InitialRAMPercentage={{ .Values.coordinator.jvm.initialHeapPercent }}
+    {{- end }}
     -XX:+{{ .Values.coordinator.jvm.gcMethod.type }}
     -XX:G1HeapRegionSize={{ .Values.coordinator.jvm.gcMethod.g1.heapRegionSize }}
     -XX:+ExplicitGCInvokesConcurrent

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -20,7 +20,18 @@ data:
   jvm.config: |
     -server
     -agentpath:/usr/lib/trino/bin/libjvmkill.so
+    {{- if .Values.worker.jvm.maxHeapSize }}
     -Xmx{{ .Values.worker.jvm.maxHeapSize }}
+    {{- end }}
+    {{- if .Values.worker.jvm.minHeapSize }}
+    -Xms{{ .Values.worker.jvm.minHeapSize }}
+    {{- end }}
+    {{- if .Values.worker.jvm.maxHeapPercent }}
+    -XX:MaxRAMPercentage={{ .Values.worker.jvm.maxHeapPercent }}
+    {{- end }}
+    {{- if .Values.worker.jvm.initialHeapPercent }}
+    -XX:InitialRAMPercentage={{ .Values.worker.jvm.initialHeapPercent }}
+    {{- end }}
     -XX:+{{ .Values.worker.jvm.gcMethod.type }}
     -XX:G1HeapRegionSize={{ .Values.worker.jvm.gcMethod.g1.heapRegionSize }}
     -XX:+ExplicitGCInvokesConcurrent

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -625,6 +625,13 @@ coordinator:
 
   jvm:
     maxHeapSize: "8G"
+    minHeapSize: "8G"
+    maxHeapPercent:
+    # coordinator.jvm.maxHeapPercent -- Alternative method of setting heap size as a percentage of container memory limits, which is recommended for better JVM ergonomics. `maxHeapSize` must be unset for this to work.
+    initialHeapPercent:
+    # coordinator.jvm.initialHeapPercent -- sets the starting heap size as a percentage of container memory limits.
+    #
+    # NOTE: to disable dynamic heap resizing when setting the size as a percent, add `-XX:MaxHeapFreeRatio=100` or `-XX:-UseAdaptiveSizePolicy` to `additionalJVMConfig`.
     gcMethod:
       type: "UseG1GC"
       g1:
@@ -808,6 +815,13 @@ worker:
 
   jvm:
     maxHeapSize: "8G"
+    minHeapSize: "8G"
+    maxHeapPercent:
+    # jvm.maxHeapPercent -- Alternative method of setting heap size as a percentage of container memory limits, which is recommended for better JVM ergonomics. `maxHeapSize` must be unset for this to work.
+    initialHeapPercent:
+    # jvm.initialHeapPercent -- sets the starting heap size as a percentage of container memory limits.
+    #
+    # NOTE: to disable dynamic heap resizing when setting the size as a percent, add `-XX:MaxHeapFreeRatio=100` or `-XX:-UseAdaptiveSizePolicy` to `additionalJVMConfig`.
     gcMethod:
       type: "UseG1GC"
       g1:

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -625,7 +625,7 @@ coordinator:
 
   jvm:
     maxHeapSize: "8G"
-    minHeapSize: "8G"
+    minHeapSize:
     maxHeapPercent:
     # coordinator.jvm.maxHeapPercent -- Alternative method of setting heap size as a percentage of container memory limits, which is recommended for better JVM ergonomics. `maxHeapSize` must be unset for this to work.
     initialHeapPercent:
@@ -815,7 +815,7 @@ worker:
 
   jvm:
     maxHeapSize: "8G"
-    minHeapSize: "8G"
+    minHeapSize:
     maxHeapPercent:
     # jvm.maxHeapPercent -- Alternative method of setting heap size as a percentage of container memory limits, which is recommended for better JVM ergonomics. `maxHeapSize` must be unset for this to work.
     initialHeapPercent:

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -38,7 +38,6 @@ server:
             sum by (service)
             (avg_over_time(trino_execution_ClusterSizeMonitor_RequiredWorkers{service={{ include "trino.fullname" . | quote }}}[5s]))
 
-
 additionalConfigProperties:
   - internal-communication.shared-secret=random-value-999
   - http-server.authentication.allow-insecure-over-http=true
@@ -64,7 +63,7 @@ auth:
 
 secretMounts:
   - name: certificates
-    secretName: '{{ .Release.Namespace }}-certificates'
+    secretName: "{{ .Release.Namespace }}-certificates"
     path: /etc/trino/certificates
 
 coordinator:
@@ -80,7 +79,8 @@ coordinator:
         maxUnavailable: 50%
 
   jvm:
-    maxHeapSize: "8G"
+    maxHeapSize: "7G"
+    minHeapSize: "7G"
     gcMethod:
       type: "UseG1GC"
       g1:
@@ -116,7 +116,10 @@ worker:
         maxUnavailable: 50%
 
   jvm:
-    maxHeapSize: "8G"
+    maxHeapSize:
+    minHeapSize:
+    maxHeapPercent: 80
+    initialHeapPercent: 50
     gcMethod:
       type: "UseG1GC"
       g1:
@@ -161,7 +164,12 @@ initContainers:
     - name: init-coordinator
       image: busybox:1.36
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', "cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem"]
+      command:
+        [
+          "sh",
+          "-c",
+          "cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem",
+        ]
       volumeMounts:
         - name: certificates
           readOnly: true
@@ -280,7 +288,6 @@ resourceGroups:
         }
       ]
     }
-
 
 jmx:
   enabled: true

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -165,7 +165,7 @@ initContainers:
     - name: init-coordinator
       image: busybox:1.36
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem']
+      command: ['sh', '-c', "cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem"]
       volumeMounts:
         - name: certificates
           readOnly: true

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -165,8 +165,7 @@ initContainers:
     - name: init-coordinator
       image: busybox:1.36
       imagePullPolicy: IfNotPresent
-      command:
-        ['sh', '-c', 'cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem']
+      command: ['sh', '-c', 'cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem']
       volumeMounts:
         - name: certificates
           readOnly: true

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -38,6 +38,7 @@ server:
             sum by (service)
             (avg_over_time(trino_execution_ClusterSizeMonitor_RequiredWorkers{service={{ include "trino.fullname" . | quote }}}[5s]))
 
+
 additionalConfigProperties:
   - internal-communication.shared-secret=random-value-999
   - http-server.authentication.allow-insecure-over-http=true
@@ -63,7 +64,7 @@ auth:
 
 secretMounts:
   - name: certificates
-    secretName: "{{ .Release.Namespace }}-certificates"
+    secretName: '{{ .Release.Namespace }}-certificates'
     path: /etc/trino/certificates
 
 coordinator:
@@ -165,11 +166,7 @@ initContainers:
       image: busybox:1.36
       imagePullPolicy: IfNotPresent
       command:
-        [
-          "sh",
-          "-c",
-          "cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem",
-        ]
+        ['sh', '-c', 'cat /etc/trino/certificates/tls.crt /etc/trino/certificates/tls.key > /etc/trino/generated/tls.pem']
       volumeMounts:
         - name: certificates
           readOnly: true
@@ -288,6 +285,7 @@ resourceGroups:
         }
       ]
     }
+
 
 jmx:
   enabled: true


### PR DESCRIPTION
This change configures -Xms the same way -Xmx is configured for consistency sake. It makes both items optional but keeps the current default values. It also adds the ability to use MaxRAMPercentage/InitialRAMPercentage as an alternative to Xmx/Xms.

Because Xmx/Xms will always override the Percentage based heap sizing they need to be nullable. I debated `fail`-ing the configuration if conflicting options were provided, but combining the settings won't prevent the jvm from starting so I opted to document and not be overly prescriptive.