### PR TITLE
add startupProbe to trino helm chart

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -575,6 +575,17 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    failureThreshold: 6
    successThreshold: 1
   ```
+* `coordinator.startupProbe` - object, default: `{}`  
+
+  [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  Example:
+  ```yaml
+   initialDelaySeconds: 10
+   periodSeconds: 2
+   timeoutSeconds: 2
+   failureThreshold: 60
+   successThreshold: 1
+  ```
 * `coordinator.lifecycle` - object, default: `{}`  
 
   Coordinator container [lifecycle events](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/)
@@ -708,6 +719,17 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
    periodSeconds: 10
    timeoutSeconds: 5
    failureThreshold: 6
+   successThreshold: 1
+  ```
+* `worker.startupProbe` - object, default: `{}`  
+
+  [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  Example:
+  ```yaml
+   initialDelaySeconds: 10
+   periodSeconds: 2
+   timeoutSeconds: 2
+   failureThreshold: 60
    successThreshold: 1
   ```
 * `worker.lifecycle` - object, default: `{}`  

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -238,6 +238,14 @@ spec:
             timeoutSeconds: {{ .Values.coordinator.readinessProbe.timeoutSeconds | default 5 }}
             failureThreshold: {{ .Values.coordinator.readinessProbe.failureThreshold | default 6 }}
             successThreshold: {{ .Values.coordinator.readinessProbe.successThreshold | default 1 }}
+          startupProbe:
+            exec:
+              command: [/usr/lib/trino/bin/health-check]
+            initialDelaySeconds: {{ .Values.coordinator.startupProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.coordinator.startupProbe.periodSeconds | default 2 }}
+            timeoutSeconds: {{ .Values.coordinator.startupProbe.timeoutSeconds | default 2 }}
+            failureThreshold: {{ .Values.coordinator.startupProbe.failureThreshold | default 60 }}
+            successThreshold: {{ .Values.coordinator.startupProbe.successThreshold | default 1 }}
           lifecycle:
             {{- tpl (toYaml .Values.coordinator.lifecycle) . | nindent 12 }}
           resources:

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -211,6 +211,14 @@ spec:
             timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds | default 5 }}
             failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold | default 6 }}
             successThreshold: {{ .Values.worker.readinessProbe.successThreshold | default 1 }}
+          startupProbe:
+            exec:
+              command: [/usr/lib/trino/bin/health-check]
+            initialDelaySeconds: {{ .Values.worker.startupProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.worker.startupProbe.periodSeconds | default 2 }}
+            timeoutSeconds: {{ .Values.worker.startupProbe.timeoutSeconds | default 2 }}
+            failureThreshold: {{ .Values.worker.startupProbe.failureThreshold | default 60 }}
+            successThreshold: {{ .Values.worker.startupProbe.successThreshold | default 1 }}
           lifecycle:
             {{- if .Values.worker.lifecycle }}
             {{- if .Values.worker.gracefulShutdown.enabled }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -700,6 +700,19 @@ coordinator:
   #  successThreshold: 1
   # ```
 
+  startupProbe: {}
+  # coordinator.startupProbe -- [Startup
+  # probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  # @raw
+  # Example:
+  # ```yaml
+  #  initialDelaySeconds: 10
+  #  periodSeconds: 2
+  #  timeoutSeconds: 2
+  #  failureThreshold: 60
+  #  successThreshold: 1
+  # ```
+
   lifecycle: {}
   # coordinator.lifecycle -- Coordinator container [lifecycle
   # events](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/)
@@ -872,6 +885,19 @@ worker:
   #  periodSeconds: 10
   #  timeoutSeconds: 5
   #  failureThreshold: 6
+  #  successThreshold: 1
+  # ```
+
+  startupProbe: {}
+  # worker.startupProbe -- [Startup
+  # probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)
+  # @raw
+  # Example:
+  # ```yaml
+  #  initialDelaySeconds: 10
+  #  periodSeconds: 2
+  #  timeoutSeconds: 2
+  #  failureThreshold: 60
   #  successThreshold: 1
   # ```
 


### PR DESCRIPTION
## Summary

Adds `startupProbe` configuration support to the Trino Helm chart for both coordinator and worker deployments.

## Changes

- Added `startupProbe` template block to `deployment-coordinator.yaml` and `deployment-worker.yaml`
- Added `startupProbe` default values in `values.yaml` for both coordinator and worker
- Updated `README.md` with documentation for the new `startupProbe` configuration options

## Motivation

The `startupProbe` allows Kubernetes to distinguish between a slow-starting container and a failed one. This is particularly useful for Trino, which can take time to initialize, preventing premature restarts during startup before liveness/readiness probes take over.