### PR TITLE
Introduce automountServiceAccountToken management

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -195,7 +195,7 @@ A Helm chart for Trino Gateway
   Specifies whether a service account should be created
 * `serviceAccount.automount` - bool, default: `true`  
 
-  Automatically mount a ServiceAccount's API credentials?
+  Automatically mount a ServiceAccount's API credentials
 * `serviceAccount.annotations` - object, default: `{}`  
 
   Annotations to add to the service account

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -251,7 +251,7 @@ securityContext: {}
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
-  # -- Automatically mount a ServiceAccount's API credentials?
+  # -- Automatically mount a ServiceAccount's API credentials
   automount: true
   # -- Annotations to add to the service account
   annotations: {}

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -486,7 +486,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
   Specifies whether a service account should be created
 * `serviceAccount.automount` - bool, default: `true`  
 
-  Automatically mount a ServiceAccount's API credentials?
+  Automatically mount a ServiceAccount's API credentials
 * `serviceAccount.name` - string, default: `""`  
 
   The name of the service account to use. If not set and create is true, a name is generated using the fullname template

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -484,6 +484,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `serviceAccount.create` - bool, default: `false`  
 
   Specifies whether a service account should be created
+* `serviceAccount.automount` - bool, default: `true`  
+
+  Automatically mount a ServiceAccount's API credentials?
 * `serviceAccount.name` - string, default: `""`  
 
   The name of the service account to use. If not set and create is true, a name is generated using the fullname template

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -484,6 +484,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `serviceAccount.create` - bool, default: `false`  
 
   Specifies whether a service account should be created
+* `serviceAccount.automount` - bool, default: `true`  
+
+  Automatically mount a ServiceAccount's API credentials
 * `serviceAccount.name` - string, default: `""`  
 
   The name of the service account to use. If not set and create is true, a name is generated using the fullname template

--- a/charts/trino/templates/serviceaccount.yaml
+++ b/charts/trino/templates/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -578,6 +578,8 @@ auth: {}
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: false
+  # -- Automatically mount a ServiceAccount's API credentials
+  automount: true
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -578,6 +578,8 @@ auth: {}
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: false
+  # -- Automatically mount a ServiceAccount's API credentials?
+  automount: true
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -578,7 +578,7 @@ auth: {}
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: false
-  # -- Automatically mount a ServiceAccount's API credentials?
+  # -- Automatically mount a ServiceAccount's API credentials
   automount: true
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
This change introduces 'serviceaccount.automount`, which defaults to false, to allow configuring the automountServiceAccountToken setting of the service account.