### PR TITLE
docs: clarify server.workerExtraConfig / coordinatorExtraConfig

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -81,8 +81,27 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
     - exchange.sink-buffers-per-partition=2
     - exchange.source-concurrent-readers=4
   ```
-* `server.workerExtraConfig` - string, default: `""`
-* `server.coordinatorExtraConfig` - string, default: `""`
+* `server.workerExtraConfig` - string, default: `""`  
+
+  Extra lines appended to the **worker** `config.properties` only. Use this for properties that are valid on workers but would make the coordinator reject startup if set there. Properties listed in `additionalConfigProperties` are merged into *both* coordinator and worker `config.properties`, so role-specific properties must use `workerExtraConfig` or `coordinatorExtraConfig` instead — otherwise Trino's strict `Configuration property 'X' was not used` check crashes the pod that does not recognise the property.
+  Example:
+  ```yaml
+  server:
+    workerExtraConfig: |
+      task.writer-count=2
+  ```
+* `server.coordinatorExtraConfig` - string, default: `""`  
+
+  Extra lines appended to the **coordinator** `config.properties` only. Use this for coordinator-exclusive properties (typically HTTP-server authentication settings such as OAuth2, JWT, or PASSWORD) that workers do not accept — adding them via `additionalConfigProperties` crashes workers with `Configuration property 'http-server.authentication.type' was not used`.
+  Example (JWT authentication):
+  ```yaml
+  server:
+    coordinatorExtraConfig: |
+      http-server.authentication.type=JWT
+      http-server.authentication.jwt.key-file=https://idp.example.com/realms/my-realm/protocol/openid-connect/certs
+      http-server.authentication.jwt.required-issuer=https://idp.example.com/realms/my-realm
+      http-server.authentication.jwt.principal-field=preferred_username
+  ```
 * `server.autoscaling` - object, default: `{"behavior":{},"enabled":false,"maxReplicas":5,"targetCPUUtilizationPercentage":50,"targetMemoryUtilizationPercentage":80}`  
 
   Configure [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) for workers (`server.keda.enabled` must be `false`).

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -84,7 +84,38 @@ server:
   #   - exchange.source-concurrent-readers=4
   # ```
 
+  # server.workerExtraConfig -- Extra lines appended to the **worker** `config.properties`
+  # only. Use this for properties that are valid on workers but would make the
+  # coordinator reject startup if set there. Properties listed in
+  # `additionalConfigProperties` are merged into *both* coordinator and worker
+  # `config.properties`, so role-specific properties must use
+  # `workerExtraConfig` or `coordinatorExtraConfig` instead — otherwise Trino's
+  # strict `Configuration property 'X' was not used` check crashes the pod that
+  # does not recognise the property.
+  # @raw
+  # Example:
+  # ```yaml
+  # server:
+  #   workerExtraConfig: |
+  #     task.writer-count=2
+  # ```
   workerExtraConfig: ""
+  # server.coordinatorExtraConfig -- Extra lines appended to the **coordinator**
+  # `config.properties` only. Use this for coordinator-exclusive properties
+  # (typically HTTP-server authentication settings such as OAuth2, JWT, or
+  # PASSWORD) that workers do not accept — adding them via
+  # `additionalConfigProperties` crashes workers with
+  # `Configuration property 'http-server.authentication.type' was not used`.
+  # @raw
+  # Example (JWT authentication):
+  # ```yaml
+  # server:
+  #   coordinatorExtraConfig: |
+  #     http-server.authentication.type=JWT
+  #     http-server.authentication.jwt.key-file=https://idp.example.com/realms/my-realm/protocol/openid-connect/certs
+  #     http-server.authentication.jwt.required-issuer=https://idp.example.com/realms/my-realm
+  #     http-server.authentication.jwt.principal-field=preferred_username
+  # ```
   coordinatorExtraConfig: ""
   # server.autoscaling -- Configure [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
   # for workers (`server.keda.enabled` must be `false`).


### PR DESCRIPTION
## What

Add helm-docs descriptions for `server.workerExtraConfig` and `server.coordinatorExtraConfig`. They are currently listed in the README with only the bare property name and no guidance, which left me chasing a 30-minute coordinator/worker mismatch the first time I tried to enable JWT authentication.

## Why

`additionalConfigProperties` is merged into **both** `config.properties` files (coordinator + worker). That is fine for cluster-wide properties, but role-specific properties — the authentication flags being the most common example — cause whichever pod does not recognise the property to crash with:

```
Configuration property 'http-server.authentication.type' was not used
```

The chart already provides the correct escape hatch (`server.coordinatorExtraConfig` / `server.workerExtraConfig`) and [templates/configmap-coordinator.yaml](https://github.com/trinodb/charts/blob/main/charts/trino/templates/configmap-coordinator.yaml) / [templates/configmap-worker.yaml](https://github.com/trinodb/charts/blob/main/charts/trino/templates/configmap-worker.yaml) already wire them through. The only thing missing is the documentation pointing users to them before they try `additionalConfigProperties` and hit the crash.

## What changed

- `charts/trino/values.yaml` — add `# server.workerExtraConfig --` and `# server.coordinatorExtraConfig --` helm-docs comments with a short explanation plus a copy-pasteable example. Added a JWT authentication example on `coordinatorExtraConfig` since that is the typical production case.
- `charts/trino/README.md` — manually regenerate just those two entries to keep the diff minimal. (My local `helm-docs v1.14.2 --chart-search-root=charts --document-dependency-values` regenerates the rest of the file with whitespace-only differences, so I reverted those lines.)

## Not changed

- No template/runtime changes. The chart already supports this; the PR is documentation only.

## Test plan

- [x] `helm-docs v1.14.2 --chart-search-root=charts` runs clean.
- [x] Rendered README snippet below matches the manual edit.
- [x] The JWT example was used in a downstream cluster ([DataX #510](https://github.com/genonai/DataX/pull/533)) to turn on JWT auth end-to-end without `additionalConfigProperties` worker crashes.