### PR TITLE
Add support for setting  jmx-exporter container environment variables

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -899,6 +899,12 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `jmx.exporter.image` - string, default: `"bitnamilegacy/jmx-exporter:1.4.0"`
 * `jmx.exporter.pullPolicy` - string, default: `"Always"`
 * `jmx.exporter.port` - int, default: `5556`
+* `jmx.exporter.env` - list, default: `[]`  
+
+  environment variables specifically for the JMX exporter container, specified as a list with explicit values
+* `jmx.exporter.envFrom` - list, default: `[]`  
+
+  environment variables specifically for the JMX exporter container, specified as a list of either `ConfigMap` or `Secret` references
 * `jmx.exporter.configProperties` - string, default: `""`  
 
   The string value is templated using `tpl`. The JMX config properties file is mounted to `/etc/jmx-exporter/jmx-exporter-config.yaml`.

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -259,6 +259,10 @@ spec:
           args:
             - "{{ $coordinatorJmx.exporter.port }}"
             - /etc/jmx-exporter/jmx-exporter-config.yaml
+          env:
+            {{- toYaml $coordinatorJmx.exporter.env | nindent 12 }}
+          envFrom:
+            {{- tpl (toYaml $coordinatorJmx.exporter.envFrom) . | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/jmx-exporter/
               name: jmx-exporter-config-volume

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -252,6 +252,10 @@ spec:
           args:
             - "{{ $workerJmx.exporter.port }}"
             - /etc/jmx-exporter/jmx-exporter-config.yaml
+          env:
+            {{- toYaml $workerJmx.exporter.env | nindent 12 }}
+          envFrom:
+            {{- tpl (toYaml $workerJmx.exporter.envFrom) . | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/jmx-exporter/
               name: jmx-exporter-config-volume

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -1109,6 +1109,11 @@ jmx:
     image: bitnamilegacy/jmx-exporter:1.4.0
     pullPolicy: Always
     port: 5556
+    env: []
+    # jmx.exporter.env -- environment variables specifically for the JMX exporter container, specified as a list with explicit values
+    envFrom: []
+    # jmx.exporter.envFrom -- environment variables specifically for the JMX exporter container, specified as a list of either `ConfigMap`
+    # or `Secret` references
     configProperties: ""
     # jmx.exporter.configProperties -- The string value is templated using `tpl`. The JMX config properties file
     # is mounted to `/etc/jmx-exporter/jmx-exporter-config.yaml`.

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -295,6 +295,9 @@ jmx:
     image: bitnamilegacy/jmx-exporter:1.4.0
     pullPolicy: Always
     port: 5556
+    env:
+      - name: JAVA_TOOL_OPTIONS
+        value: -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints --module-path=/opt/bitnami/bc-fips/ -Djava.security.properties==/opt/bitnami/java/conf/security/java.security.restricted
     configProperties: |
       startDelaySeconds: 0
       hostPort: 127.0.0.1:{{- .Values.jmx.registryPort }}
@@ -302,6 +305,17 @@ jmx:
         - pattern: 'trino.memory*'
         - pattern: 'trino.execution<name=QueryManager>*'
         - pattern: 'trino.execution<name=ClusterSizeMonitor>*'
+    coordinator:
+      env:
+        - name: JAVA_TOOL_OPTIONS
+          value: -Xmx800m --module-path=/opt/bitnami/bc-fips/ -Djava.security.properties==/opt/bitnami/java/conf/security/java.security.restricted
+      resources:
+        limits:
+          cpu: 500m
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 512Mi
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
The main use for this is to be able to better tune the heap size for large deployments via setting `JAVA_TOOL_OPTIONS`