### PR TITLE
Add support for the appProtocol field in service definitions

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -459,6 +459,9 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `service.annotations` - object, default: `{}`
 * `service.type` - string, default: `"ClusterIP"`
 * `service.port` - int, default: `8080`
+* `service.appProtocol` - string, default: `"kubernetes.io/h2c"`  
+
+  A hint for gateways indicating the application protocol the service uses. The default value is the kubernetes-defined prefixed name for http2 over cleartext. some gateway implementations like istio expect `http2` as the protocol name instead. If `internal-communication.http2.enabled=false` is set in the server configuration, set this to `http` to indicate the gateway should use http1.1.
 * `service.nodePort` - string, default: `""`  
 
   The port the service listens on the host, for the `NodePort` type. If not set, Kubernetes will [allocate a port automatically](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport-custom-port).

--- a/charts/trino/templates/service-coordinator.yaml
+++ b/charts/trino/templates/service-coordinator.yaml
@@ -15,6 +15,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+      appProtocol: {{ .Values.service.appProtocol }}
       name: http
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
@@ -29,6 +30,7 @@ spec:
     - port: {{ $coordinatorJmx.exporter.port }}
       targetPort: jmx-exporter
       protocol: TCP
+      appProtocol: http
       name: jmx-exporter
       {{- if $coordinatorJmx.exporter.nodePort }}
       nodePort: {{ $coordinatorJmx.exporter.nodePort }}

--- a/charts/trino/templates/service-worker.yaml
+++ b/charts/trino/templates/service-worker.yaml
@@ -15,17 +15,20 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+      appProtocol: {{ .Values.service.appProtocol }}
       name: http
     {{- if $workerJmx.exporter.enabled }}
     - port: {{$workerJmx.exporter.port }}
       targetPort: jmx-exporter
       protocol: TCP
+      appProtocol: http
       name: jmx-exporter
     {{- end }}
     {{- range $key, $value := .Values.worker.additionalExposedPorts }}
     - port: {{ $value.servicePort }}
       name: {{ $value.name }}
       targetPort: {{ $value.port }}
+      appProtocol: {{ $value.appProtocol }}
       protocol: {{ $value.protocol }}
       {{- if $value.nodePort }}
       nodePort: {{ $value.nodePort }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -550,6 +550,12 @@ service:
   annotations: {}
   type: ClusterIP
   port: 8080
+  # -- A hint for gateways indicating the application protocol the service uses. The default value is the
+  # kubernetes-defined prefixed name for http2 over cleartext. some gateway implementations like istio
+  # expect `http2` as the protocol name instead. If `internal-communication.http2.enabled=false` is set
+  # in the server configuration, set this to `http` to indicate the gateway should use http1.1.
+  appProtocol: kubernetes.io/h2c
+
   # service.nodePort -- The port the service listens on the host, for the `NodePort` type. If not set, Kubernetes will
   # [allocate a port
   # automatically](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport-custom-port).


### PR DESCRIPTION
fixes #384 

in Service Mesh deployments, gateways and proxies can't determine whether plaintext http is using http1.1 or http2. The appProtocol field removes the ambiguity by allowing explicit protocol selection.