### PR TITLE
Add OPA sidecar for the coordinator

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -67,8 +67,9 @@ jobs:
           - { label: default, args: '' }
           # last Trino version that requires JDK 21
           - { label: 446, args: '-a "--set image.tag=446"' }
-          # last Trino version that requires JDK 17
-          - { label: 435, args: '-a "--set image.tag=435"' }
+          # last Trino version that requires JDK 17; OPA access-control was
+          # introduced in Trino 438, so the `opa` test scenario is excluded
+          - { label: 435, args: '-a "--set image.tag=435" -x opa' }
           # skip cleanup to test deploying multiple releases in a single namespace
           - { label: overrides, args: '-s -t default,overrides' }
     steps:

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.42.2
+version: 1.43.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 1.42.2](https://img.shields.io/badge/Version-1.42.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 480](https://img.shields.io/badge/AppVersion-480-informational?style=flat-square)
+![Version: 1.43.0](https://img.shields.io/badge/Version-1.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 480](https://img.shields.io/badge/AppVersion-480-informational?style=flat-square)
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe
 
@@ -243,6 +243,92 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
          ]
        }
   ```
+* `opa.enabled` - bool, default: `false`  
+
+  Set to true to deploy an [Open Policy Agent](https://www.openpolicyagent.org/) sidecar container on the Trino coordinator pod.
+  When `opa.enabled` is true and `accessControl` is left at its default
+  (empty `{}`), the chart automatically wires Trino's access-control plugin
+  to this sidecar using `opa.policyUri` and the optional `opa.*Uri` /
+  `opa.log*` / `opa.allowPermissionManagementOperations` values. To
+  customize further, set `accessControl.type: properties` and provide the
+  full `accessControl.properties` block; any `accessControl` value disables
+  auto-wiring.
+* `opa.image` - string, default: `"openpolicyagent/opa:1.16.2-static"`  
+
+  OPA container image. The `-static` variant is recommended: it ships without a shell which keeps the attack surface small. Check for newer versions at https://hub.docker.com/r/openpolicyagent/opa/tags
+* `opa.pullPolicy` - string, default: `"IfNotPresent"`
+* `opa.listenAddress` - string, default: `"0.0.0.0"`  
+
+  Address OPA binds to inside the coordinator pod. Must remain reachable from the kubelet (which probes the pod IP), so binding to a non-routable address such as `127.0.0.1` will break the default `httpGet` probes.
+* `opa.port` - int, default: `8181`  
+
+  Port OPA listens on inside the coordinator pod. Must match the host portion of `opa.policyUri` and the other URI values.
+* `opa.policyUri` - string, default: `"http://127.0.0.1:8181/v1/data/trino/allow"`  
+
+  URI Trino uses to fetch authorization decisions from OPA.
+* `opa.columnMaskingUri` - string, default: `""`  
+
+  Optional URI for column-masking decisions. When set, the auto-wired access-control adds `opa.policy.column-masking-uri`. Leave empty to omit.
+* `opa.rowFiltersUri` - string, default: `""`  
+
+  Optional URI for row-filter decisions. When set, the auto-wired access-control adds `opa.policy.row-filters-uri`. Leave empty to omit.
+* `opa.batchedUri` - string, default: `""`  
+
+  Optional URI for batched authorization decisions. When set, the auto-wired access-control adds `opa.policy.batched-uri`. Leave empty to omit.
+* `opa.logRequests` - bool, default: `false`  
+
+  When true, the auto-wired access-control adds `opa.log-requests=true`, logging every request Trino sends to OPA.
+* `opa.logResponses` - bool, default: `false`  
+
+  When true, the auto-wired access-control adds `opa.log-responses=true`, logging every response Trino receives from OPA.
+* `opa.allowPermissionManagementOperations` - bool, default: `false`  
+
+  When true, the auto-wired access-control adds `opa.allow-permission-management-operations=true`, allowing CREATE/DROP ROLE, GRANT, REVOKE, and similar statements without OPA evaluation.
+* `opa.policy` - object, default: `{}`  
+
+  Rego policy files to render into a ConfigMap and mount into the OPA container at `opa.policyMountPath`. Provide one or more entries, each keyed by file name (e.g. `policy.rego`, `data.json`). Mutually exclusive with `opa.policyConfigMap`. Exactly one of the two must be set when `opa.enabled` is true.
+  Example:
+  ```yaml
+  policy:
+    policy.rego: |
+      package trino
+      import rego.v1
+      default allow := false
+      allow if {
+        input.context.identity.user == "alice"
+      }
+  ```
+* `opa.policyConfigMap` - string, default: `""`  
+
+  Name of an existing ConfigMap holding the OPA policy files. Mutually exclusive with `opa.policy`.
+* `opa.policyMountPath` - string, default: `"/policies"`  
+
+  Directory inside the OPA container where the policy files are mounted.
+* `opa.extraArgs` - list, default: `[]`  
+
+  Additional flags appended to the `opa run` command, before the policy directory positional argument.
+  Example:
+  ```yaml
+  extraArgs:
+    - --log-level=debug
+  ```
+* `opa.securityContext` - object, default: `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}`  
+
+  [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the OPA container. Defaults to a hardened, non-root, read-only-root configuration. Override fields explicitly if your environment requires it.
+* `opa.resources` - object, default: `{"limits":{"memory":"512Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}`  
+
+  Resource requests and limits for the OPA container.
+  Set to `{}` to opt out of any resource defaults.
+* `opa.livenessProbe.initialDelaySeconds` - int, default: `5`
+* `opa.livenessProbe.periodSeconds` - int, default: `10`
+* `opa.livenessProbe.timeoutSeconds` - int, default: `5`
+* `opa.livenessProbe.failureThreshold` - int, default: `3`
+* `opa.livenessProbe.successThreshold` - int, default: `1`
+* `opa.readinessProbe.initialDelaySeconds` - int, default: `5`
+* `opa.readinessProbe.periodSeconds` - int, default: `10`
+* `opa.readinessProbe.timeoutSeconds` - int, default: `5`
+* `opa.readinessProbe.failureThreshold` - int, default: `3`
+* `opa.readinessProbe.successThreshold` - int, default: `1`
 * `headerAuthenticator` - object, default: `{}`  
 
   [Header authenticator](https://trino.io/docs/current/develop/header-authenticator.html) configuration. Required when `server.config.authenticationType` contains `HEADER`.

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -109,6 +109,28 @@ data:
   {{- else}}
   {{- fail "Invalid accessControl.type value. It must be either 'configmap' or 'properties'." }}
   {{- end }}
+{{- else if .Values.opa.enabled }}
+  access-control.properties: |
+    access-control.name=opa
+    opa.policy.uri={{ .Values.opa.policyUri }}
+    {{- if .Values.opa.columnMaskingUri }}
+    opa.policy.column-masking-uri={{ .Values.opa.columnMaskingUri }}
+    {{- end }}
+    {{- if .Values.opa.rowFiltersUri }}
+    opa.policy.row-filters-uri={{ .Values.opa.rowFiltersUri }}
+    {{- end }}
+    {{- if .Values.opa.batchedUri }}
+    opa.policy.batched-uri={{ .Values.opa.batchedUri }}
+    {{- end }}
+    {{- if .Values.opa.logRequests }}
+    opa.log-requests=true
+    {{- end }}
+    {{- if .Values.opa.logResponses }}
+    opa.log-responses=true
+    {{- end }}
+    {{- if .Values.opa.allowPermissionManagementOperations }}
+    opa.allow-permission-management-operations=true
+    {{- end }}
 {{- end }}
 
 {{- if .Values.resourceGroups }}

--- a/charts/trino/templates/configmap-opa-policy-coordinator.yaml
+++ b/charts/trino/templates/configmap-opa-policy-coordinator.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.opa.enabled }}
+{{- if and (gt (len .Values.opa.policy) 0) .Values.opa.policyConfigMap }}
+{{- fail "opa.policy and opa.policyConfigMap are mutually exclusive: set exactly one." }}
+{{- end }}
+{{- with .Values.image }}
+{{- if and (eq .repository "trinodb/trino") (not .useRepositoryAsSoleImageReference) (not .registry) (not .digest) (lt (default $.Chart.AppVersion .tag | int) 438) }}
+{{- fail "opa.enabled requires Trino 438 or later (the OPA access-control plugin was introduced in release 438). Set image.tag to 438+ or use a custom image." }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.opa.enabled (not .Values.opa.policyConfigMap) }}
+{{- if eq (len .Values.opa.policy) 0 }}
+{{- fail "opa.enabled is true but no policy was provided. Set either opa.policy (map of filename: content) or opa.policyConfigMap (name of an existing ConfigMap)." }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "trino.fullname" . }}-opa-policy-coordinator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opa
+data:
+  {{- range $name, $content := .Values.opa.policy }}
+  {{ $name }}: |-
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -101,6 +101,11 @@ spec:
           configMap:
             name: {{ template "trino.fullname" . }}-jmx-exporter-config-coordinator
         {{- end }}
+        {{- if .Values.opa.enabled }}
+        - name: opa-policy-volume
+          configMap:
+            name: {{ .Values.opa.policyConfigMap | default (printf "%s-opa-policy-coordinator" (include "trino.fullname" .)) }}
+        {{- end }}
         {{- range .Values.configMounts }}
         - name: {{ .name }}
           configMap:
@@ -268,6 +273,52 @@ spec:
             - name: jmx-exporter
               containerPort: {{ $coordinatorJmx.exporter.port }}
               protocol: TCP
+      {{- end }}
+      {{- if .Values.opa.enabled }}
+        - name: opa
+          image: {{ .Values.opa.image }}
+          imagePullPolicy: {{ .Values.opa.pullPolicy }}
+          {{- with .Values.opa.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - run
+            - --server
+            - --addr={{ .Values.opa.listenAddress }}:{{ .Values.opa.port }}
+            - --log-format=json
+            - --watch
+            - --ignore=..*
+            {{- range .Values.opa.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+            - {{ .Values.opa.policyMountPath }}
+          volumeMounts:
+            - name: opa-policy-volume
+              mountPath: {{ .Values.opa.policyMountPath }}
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.opa.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.opa.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.opa.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.opa.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.opa.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.opa.livenessProbe.successThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /health?plugins
+              port: {{ .Values.opa.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.opa.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.opa.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.opa.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.opa.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.opa.readinessProbe.successThreshold }}
+          resources:
+            {{- toYaml .Values.opa.resources | nindent 12 }}
       {{- end }}
       {{- if .Values.sidecarContainers.coordinator }}
         {{- toYaml .Values.sidecarContainers.coordinator | nindent 8 }}

--- a/charts/trino/templates/tests/test-opa.yaml
+++ b/charts/trino/templates/tests/test-opa.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.opa.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "trino.fullname" . }}-test-opa
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+    test: opa
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  containers:
+    - name: opa-policy-test
+      image: {{ include "trino.image" . }}
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          set -u
+          TRINO_URL="trino://{{ include "trino.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}"
+          QUERY="SELECT 1"
+
+          echo "==> Negative test: denied-user must be rejected by OPA"
+          set +e
+          OUTPUT=$(trino "$TRINO_URL" --user=denied-user --execute="$QUERY" --no-progress --output-format=CSV 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ "$STATUS" -eq 0 ]; then
+            echo "FAIL: denied-user query unexpectedly succeeded"
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -qE 'Access Denied|Permission denied'; then
+            echo "FAIL: denied-user query failed but not because of OPA denial"
+            exit 1
+          fi
+          echo "PASS: OPA correctly denied unauthorized user"
+
+          echo "==> Positive test: alice must be allowed by OPA"
+          OUTPUT=$(trino "$TRINO_URL" --user=alice --execute="$QUERY" --no-progress --output-format=CSV)
+          echo "$OUTPUT"
+          # Strip whitespace and quotes; CSV output wraps integers as "1"
+          CLEANED=$(echo "$OUTPUT" | tr -d '[:space:]"')
+          if [ "$CLEANED" != "1" ]; then
+            echo "FAIL: alice query did not return the expected result"
+            exit 1
+          fi
+          echo "PASS: OPA correctly allowed authorized user"
+  restartPolicy: Never
+{{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -253,6 +253,121 @@ accessControl: {}
 #      }
 # ```
 
+opa:
+  # -- Set to true to deploy an [Open Policy Agent](https://www.openpolicyagent.org/)
+  # sidecar container on the Trino coordinator pod.
+  # @raw
+  # When `opa.enabled` is true and `accessControl` is left at its default
+  # (empty `{}`), the chart automatically wires Trino's access-control plugin
+  # to this sidecar using `opa.policyUri` and the optional `opa.*Uri` /
+  # `opa.log*` / `opa.allowPermissionManagementOperations` values. To
+  # customize further, set `accessControl.type: properties` and provide the
+  # full `accessControl.properties` block; any `accessControl` value disables
+  # auto-wiring.
+  enabled: false
+  # -- OPA container image. The `-static` variant is recommended: it ships
+  # without a shell which keeps the attack surface small. Check for newer
+  # versions at https://hub.docker.com/r/openpolicyagent/opa/tags
+  image: openpolicyagent/opa:1.16.2-static
+  pullPolicy: IfNotPresent
+  # -- Address OPA binds to inside the coordinator pod. Must remain reachable
+  # from the kubelet (which probes the pod IP), so binding to a non-routable
+  # address such as `127.0.0.1` will break the default `httpGet` probes.
+  listenAddress: 0.0.0.0
+  # -- Port OPA listens on inside the coordinator pod.
+  # Must match the host portion of `opa.policyUri` and the other URI values.
+  port: 8181
+  # -- URI Trino uses to fetch authorization decisions from OPA.
+  policyUri: http://127.0.0.1:8181/v1/data/trino/allow
+  # -- Optional URI for column-masking decisions. When set, the auto-wired
+  # access-control adds `opa.policy.column-masking-uri`. Leave empty to omit.
+  columnMaskingUri: ""
+  # -- Optional URI for row-filter decisions. When set, the auto-wired
+  # access-control adds `opa.policy.row-filters-uri`. Leave empty to omit.
+  rowFiltersUri: ""
+  # -- Optional URI for batched authorization decisions. When set, the
+  # auto-wired access-control adds `opa.policy.batched-uri`. Leave empty to
+  # omit.
+  batchedUri: ""
+  # -- When true, the auto-wired access-control adds `opa.log-requests=true`,
+  # logging every request Trino sends to OPA.
+  logRequests: false
+  # -- When true, the auto-wired access-control adds `opa.log-responses=true`,
+  # logging every response Trino receives from OPA.
+  logResponses: false
+  # -- When true, the auto-wired access-control adds
+  # `opa.allow-permission-management-operations=true`, allowing CREATE/DROP
+  # ROLE, GRANT, REVOKE, and similar statements without OPA evaluation.
+  allowPermissionManagementOperations: false
+  # -- Rego policy files to render into a ConfigMap and mount into the OPA
+  # container at `opa.policyMountPath`. Provide one or more entries, each keyed
+  # by file name (e.g. `policy.rego`, `data.json`). Mutually exclusive with
+  # `opa.policyConfigMap`. Exactly one of the two must be set when
+  # `opa.enabled` is true.
+  # @raw
+  # Example:
+  # ```yaml
+  # policy:
+  #   policy.rego: |
+  #     package trino
+  #     import rego.v1
+  #     default allow := false
+  #     allow if {
+  #       input.context.identity.user == "alice"
+  #     }
+  # ```
+  policy: {}
+  # -- Name of an existing ConfigMap holding the OPA policy files.
+  # Mutually exclusive with `opa.policy`.
+  policyConfigMap: ""
+  # -- Directory inside the OPA container where the policy files are mounted.
+  policyMountPath: /policies
+  # -- Additional flags appended to the `opa run` command, before the policy
+  # directory positional argument.
+  # @raw
+  # Example:
+  # ```yaml
+  # extraArgs:
+  #   - --log-level=debug
+  # ```
+  extraArgs: []
+  # -- [Security
+  # context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  # for the OPA container. Defaults to a hardened, non-root, read-only-root
+  # configuration. Override fields explicitly if your environment requires it.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Resource requests and limits for the OPA container.
+  # @raw
+  # Set to `{}` to opt out of any resource defaults.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+
 headerAuthenticator: {}
 # headerAuthenticator -- [Header authenticator](https://trino.io/docs/current/develop/header-authenticator.html)
 # configuration. Required when `server.config.authenticationType` contains `HEADER`.

--- a/tests/trino/test-opa-values.yaml
+++ b/tests/trino/test-opa-values.yaml
@@ -1,0 +1,21 @@
+# Test values for the OPA sidecar.
+
+opa:
+  enabled: true
+  policy:
+    policy.rego: |
+      package trino
+      import rego.v1
+      default allow := false
+      allowed_users := {"alice", "admin"}
+      allow if {
+        input.context.identity.user in allowed_users
+      }
+
+server:
+  workers: 0
+
+coordinator:
+  config:
+    nodeScheduler:
+      includeCoordinator: true

--- a/tests/trino/test.sh
+++ b/tests/trino/test.sh
@@ -12,6 +12,7 @@ declare -A testCases=(
     [graceful_shutdown]="--values test-graceful-shutdown-values.yaml"
     [resource_groups_properties]="--values test-resource-groups-properties-values.yaml"
     [gateway]="--values test-gateway-values.yaml"
+    [opa]="--values test-opa-values.yaml"
 )
 
 declare -A testCaseCharts=(
@@ -24,6 +25,7 @@ declare -A testCaseCharts=(
     [graceful_shutdown]="../../charts/trino"
     [resource_groups_properties]="../../charts/trino"
     [gateway]="../../charts/trino"
+    [opa]="../../charts/trino"
 )
 
 function join_by {
@@ -43,22 +45,24 @@ CT_ARGS=(
     --helm-extra-args="--timeout 2m"
 )
 CLEANUP_NAMESPACE=true
-TEST_NAMES=(default single_node complete_values access_control_properties_values exchange_manager_values graceful_shutdown resource_groups_properties gateway)
+TEST_NAMES=(default single_node complete_values access_control_properties_values exchange_manager_values graceful_shutdown resource_groups_properties gateway opa)
+EXCLUDE_TESTS=()
 
 usage() {
     cat <<EOF 1>&2
-Usage: $0 [-h] [-n <NAMESPACE>] [-a <HELM_EXTRA_SET_ARGS>] [-t <TESTS>] [-s]
+Usage: $0 [-h] [-n <NAMESPACE>] [-a <HELM_EXTRA_SET_ARGS>] [-t <TESTS>] [-x <TESTS>] [-s]
 Test the Trino chart
 
 -h       Display help
 -n       Kubernetes namespace, a randomly generated one is used if not provided
 -a       Extra Helm set args
 -t       Test names to run, comma separated; defaults to $(join_by , "${TEST_NAMES[@]}")
+-x       Test names to exclude, comma separated; applied after -t
 -s       Skip chart cleanup
 EOF
 }
 
-while getopts ":a:n:t:sh:" OPTKEY; do
+while getopts ":a:n:t:x:sh:" OPTKEY; do
     case "${OPTKEY}" in
         a)
             HELM_EXTRA_SET_ARGS=${OPTARG}
@@ -68,6 +72,9 @@ while getopts ":a:n:t:sh:" OPTKEY; do
             ;;
         t)
             IFS=, read -ra TEST_NAMES <<<"$OPTARG"
+            ;;
+        x)
+            IFS=, read -ra EXCLUDE_TESTS <<<"$OPTARG"
             ;;
         s)
             CLEANUP_NAMESPACE=false
@@ -83,6 +90,24 @@ while getopts ":a:n:t:sh:" OPTKEY; do
     esac
 done
 shift $((OPTIND - 1))
+
+# Apply -x exclusions to TEST_NAMES
+if [ ${#EXCLUDE_TESTS[@]} -gt 0 ]; then
+    FILTERED=()
+    for name in "${TEST_NAMES[@]}"; do
+        skip=false
+        for excluded in "${EXCLUDE_TESTS[@]}"; do
+            if [ "$name" = "$excluded" ]; then
+                skip=true
+                break
+            fi
+        done
+        if [ "$skip" = false ]; then
+            FILTERED+=("$name")
+        fi
+    done
+    TEST_NAMES=("${FILTERED[@]}")
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 cd "${SCRIPT_DIR}" || exit 2


### PR DESCRIPTION
## Summary

- Adds an [Open Policy Agent](https://www.openpolicyagent.org/) sidecar to the Trino coordinator pod, configured via a new top-level `opa.*` values block.
- Auto-wires `access-control.properties` when `opa.enabled=true` and `accessControl` is unset. User-supplied `accessControl` is respected unchanged, so existing installs are unaffected.
- Adds a helm test (`test-opa.yaml`) covering both denied and allowed users, and an `opa` CI scenario in `tests/trino/test.sh`.
- Bumps the chart version to 1.43.0.

## Motivation
OPA is the policy engine behind Trino's [OPA access-control plugin](https://trino.io/docs/current/security/opa-access-control.html).
Until now, operators had to wire it manually via `sidecarContainers.coordinator` plus `accessControl.properties`, duplicating logic across deployments. This PR adds OPA as a built-in chart option: users supply a policy, the chart handles sidecar wiring, access-control properties, probes, and security context.

## Testing
- `helm lint charts/trino` and `helm lint -f tests/trino/test-opa-values.yaml`.
- `helm template` verified for: default (no OPA), opa-enabled inline policy, opa-enabled with external `policyConfigMap`, opa-enabled with manual `accessControl` (auto-wire skipped), and the two failure paths (empty policy → fail, both `policy` and `policyConfigMap` set → fail).
- `./tests/trino/test.sh -t opa` end-to-end on kind: both `test-connection` (admin) and `test-opa` (denied + allowed) pass.

## Docs
- `helm-docs` regenerated.
- See https://trino.io/docs/current/security/opa-access-control.html