### PR TITLE
Add worker PodDisruptionBudget to trino helm chart

### DIFF
--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -678,6 +678,14 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 * `worker.deployment.strategy` - object, default: `{}`  
 
   The deployment strategy to use to replace existing pods with new ones.
+* `worker.podDisruptionBudget` - object, default: `{}`  
+
+  Worker [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) configuration. Configure one of the following options: `minAvailable` - minimum number of worker pods that must stay available. `maxUnavailable` - maximum number of worker pods that can be unavailable.
+  Example:
+  ```yaml
+  podDisruptionBudget:
+    minAvailable: 1
+  ```
 * `worker.jvm.maxHeapSize` - string, default: `"8G"`
 * `worker.jvm.minHeapSize` - string, default: `nil`
 * `worker.jvm.maxHeapPercent` - string, default: `nil`

--- a/charts/trino/templates/poddisruptionbudget-worker.yaml
+++ b/charts/trino/templates/poddisruptionbudget-worker.yaml
@@ -1,0 +1,28 @@
+{{- $workerPdb := .Values.worker.podDisruptionBudget | default dict -}}
+{{- $hasMinAvailable := hasKey $workerPdb "minAvailable" -}}
+{{- $hasMaxUnavailable := hasKey $workerPdb "maxUnavailable" -}}
+
+{{- if and $hasMinAvailable $hasMaxUnavailable -}}
+{{- fail "The `worker.podDisruptionBudget` configuration must define only one of `minAvailable` or `maxUnavailable`." -}}
+{{- end -}}
+
+{{- if and (or (gt (int .Values.server.workers) 0) .Values.server.keda.enabled) (or $hasMinAvailable $hasMaxUnavailable) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "trino.worker" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "trino.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  selector:
+    matchLabels:
+      {{- include "trino.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  {{- if $hasMinAvailable }}
+  minAvailable: {{ $workerPdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ $workerPdb.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -827,6 +827,20 @@ worker:
     strategy: {}
     # worker.deployment.strategy -- The deployment strategy to use to replace existing pods with new ones.
 
+  podDisruptionBudget: {}
+  # worker.podDisruptionBudget -- Worker [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  # configuration.
+  # Configure one of the following options:
+  # `minAvailable` - minimum number of worker pods that must stay available.
+  # `maxUnavailable` - maximum number of worker pods that can be unavailable.
+  #
+  # @raw
+  # Example:
+  # ```yaml
+  # podDisruptionBudget:
+  #   minAvailable: 1
+  # ```
+
   jvm:
     maxHeapSize: "8G"
     minHeapSize:

--- a/tests/trino/test-values.yaml
+++ b/tests/trino/test-values.yaml
@@ -116,6 +116,8 @@ worker:
         maxSurge: 25%
         maxUnavailable: 50%
 
+  podDisruptionBudget: {}
+
   jvm:
     maxHeapSize:
     minHeapSize:


### PR DESCRIPTION
Add worker PodDisruptionBudget support to the trino chart with configurable options under `worker.podDisruptionBudget`.

