### PR TITLE
Bump Trino to 481 and release chart 1.42.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the name to get an output similar to the following:
 
 ```
 NAME               	CHART VERSION	APP VERSION	DESCRIPTION
-trino/trino        	1.42.2       	480        	Fast distributed SQL query engine for big data ...
+trino/trino        	1.42.3       	481        	Fast distributed SQL query engine for big data ...
 trino/trino-gateway	1.20.0       	20         	A Helm chart for Trino Gateway
 ```
 
@@ -35,7 +35,7 @@ After configuring your Kubernetes cluster, you can install Trino with the chart
 `trino/trino` using:
 
 ```console
-helm install my-trino trino/trino --version 1.42.2
+helm install my-trino trino/trino --version 1.42.3
 ```
 
 Also, you can check the manifests using:
@@ -72,7 +72,7 @@ ct install
 
 To run tests with specific values:
 ```console
-ct install --helm-extra-set-args "--set image.tag=480"
+ct install --helm-extra-set-args "--set image.tag=481"
 ```
 
 Use the `test.sh` script to run a suite of tests, with different chart values.

--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.42.2
+version: 1.42.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # Same value as in values.yml#image.tag
-appVersion: "480"
+appVersion: "481"
 
 icon: https://trino.io/assets/trino.png
 

--- a/charts/trino/README.md
+++ b/charts/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 1.42.2](https://img.shields.io/badge/Version-1.42.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 480](https://img.shields.io/badge/AppVersion-480-informational?style=flat-square)
+![Version: 1.42.3](https://img.shields.io/badge/Version-1.42.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 481](https://img.shields.io/badge/AppVersion-481-informational?style=flat-square)
 
 Fast distributed SQL query engine for big data analytics that helps you explore your data universe
 


### PR DESCRIPTION
## Changes
- Update `appVersion` to `481` (Trino 481, released 2026-05-12)
- Bump chart version to `1.42.3`
- Update version references in README files