### PR TITLE
Avoid duplicate checksum annotations on Trino pods

### DIFF
--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -28,16 +28,17 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if and (eq .Values.accessControl.type "configmap") (not .Values.accessControl.refreshPeriod) }}
-        checksum/access-control-config: {{ include (print $.Template.BasePath "/configmap-access-control-coordinator.yaml") . | sha256sum }}
+        {{- $annotations := deepCopy (.Values.coordinator.annotations | default dict) }}
+        {{- if and (eq .Values.accessControl.type "configmap") (not .Values.accessControl.refreshPeriod) (not (hasKey $annotations "checksum/access-control-config")) }}
+        {{- $_ := set $annotations "checksum/access-control-config" (include (print $.Template.BasePath "/configmap-access-control-coordinator.yaml") . | sha256sum) }}
         {{- end }}
-        {{- if or .Values.catalogs .Values.additionalCatalogs }}
-        checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        {{- if and (or .Values.catalogs .Values.additionalCatalogs) (not (hasKey $annotations "checksum/catalog-config")) }}
+        {{- $_ := set $annotations "checksum/catalog-config" (include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum) }}
         {{- end }}
-        checksum/coordinator-config: {{ include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum }}
-      {{- if .Values.coordinator.annotations }}
-      {{- tpl (toYaml .Values.coordinator.annotations) . | nindent 8 }}
-      {{- end }}
+        {{- if not (hasKey $annotations "checksum/coordinator-config") }}
+        {{- $_ := set $annotations "checksum/coordinator-config" (include (print $.Template.BasePath "/configmap-coordinator.yaml") . | sha256sum) }}
+        {{- end }}
+        {{- tpl (toYaml $annotations) . | nindent 8 }}
 
       labels:
         {{- include "trino.labels" . | nindent 8 }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -31,16 +31,17 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if or .Values.catalogs .Values.additionalCatalogs }}
-        checksum/catalog-config: {{ include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum }}
+        {{- $annotations := deepCopy (.Values.worker.annotations | default dict) }}
+        {{- if and (or .Values.catalogs .Values.additionalCatalogs) (not (hasKey $annotations "checksum/catalog-config")) }}
+        {{- $_ := set $annotations "checksum/catalog-config" (include (print $.Template.BasePath "/configmap-catalog.yaml") . | sha256sum) }}
         {{- end }}
-        checksum/worker-config: {{ include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum }}
-      {{- if .Values.worker.gracefulShutdown.enabled }}
-        checksum/access-control-config: {{ include (print $.Template.BasePath "/configmap-access-control-worker.yaml") . | sha256sum }}
-      {{- end }}
-      {{- if .Values.worker.annotations }}
-      {{- tpl (toYaml .Values.worker.annotations) . | nindent 8 }}
-      {{- end }}
+        {{- if not (hasKey $annotations "checksum/worker-config") }}
+        {{- $_ := set $annotations "checksum/worker-config" (include (print $.Template.BasePath "/configmap-worker.yaml") . | sha256sum) }}
+        {{- end }}
+        {{- if and .Values.worker.gracefulShutdown.enabled (not (hasKey $annotations "checksum/access-control-config")) }}
+        {{- $_ := set $annotations "checksum/access-control-config" (include (print $.Template.BasePath "/configmap-access-control-worker.yaml") . | sha256sum) }}
+        {{- end }}
+        {{- tpl (toYaml $annotations) . | nindent 8 }}
       labels:
         {{- include "trino.labels" . | nindent 8 }}
         app.kubernetes.io/component: worker


### PR DESCRIPTION
Fixes #432

### Problem

The coordinator and worker pod templates emit the generated `checksum/*` annotations and then append the user-supplied `coordinator.annotations` / `worker.annotations` block separately. `values.yaml` documents overriding these checksums by setting them to fixed constants, but doing so produces **two annotation entries with the same key**.

Helm tolerates duplicate mapping keys (last wins), so this appears to work with `helm template` / `helm install`. Strict YAML parsers reject them — notably **kustomize** and `kubectl apply` post-render pipelines fail to parse the output.

### Fix

Build the pod annotations into a single map, adding each generated checksum only when the user has not already supplied that key (`hasKey` guard), then render once. The user value takes precedence and each key is emitted exactly once.

- `hasKey` guard rather than sprig `merge`, so a user value of `""` is preserved — sprig/mergo treats an empty string as unset and would overwrite it, breaking the documented disable pattern.
- `deepCopy` so `set` does not mutate the shared `.Values`.

### Verification

```console
$ helm template demo charts/trino -f override.yaml | grep checksum/coordinator-config
        checksum/coordinator-config: pinned-by-user
```

Single entry. `kubectl kustomize` on the rendered Deployment now succeeds (previously failed with `mapping key "checksum/coordinator-config" already defined`). Default render still includes the generated checksums; `helm lint` passes.

### Note

I left the chart `version` in `Chart.yaml` unbumped so maintainers can batch it with any other fixes in the next release.
