### PR TITLE
Release Trino Gateway chart 1.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the name to get an output similar to the following:
 ```
 NAME               	CHART VERSION	APP VERSION	DESCRIPTION
 trino/trino        	1.42.2       	480        	Fast distributed SQL query engine for big data ...
-trino/trino-gateway	1.21.0       	21         	A Helm chart for Trino Gateway
+trino/trino-gateway	1.22.0       	22         	A Helm chart for Trino Gateway
 ```
 
 Use `helm search repo trino -l` for information about all available versions.

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trino-gateway
 description: A Helm chart for Trino Gateway
 type: application
-version: "1.21.0"
-appVersion: "21"
+version: "1.22.0"
+appVersion: "22"
 
 icon: https://trino.io/assets/images/logos/trino-gateway-small.png
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1,6 +1,6 @@
 # trino-gateway
 
-![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 21](https://img.shields.io/badge/AppVersion-21-informational?style=flat-square)
+![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 22](https://img.shields.io/badge/AppVersion-22-informational?style=flat-square)
 
 A Helm chart for Trino Gateway
 


### PR DESCRIPTION
Pending Trino Gateway 22 release. CI is known to fail until the 22 container image is published.

Release notes PR at https://github.com/trinodb/trino-gateway/pull/1260